### PR TITLE
[ fix ] Reverse arguments in `case` unelaboration

### DIFF
--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -81,8 +81,9 @@ mutual
                 | _ => pure Nothing
            let Just argpos = findArgPos treect
                 | _ => pure Nothing
-           if length args == length pargs
-              then mkCase pats argpos args
+           let len = length args
+           if len == length pargs
+              then mkCase pats (len `minus` argpos + 1) args
               else pure Nothing
     where
       -- Need to find the position of the scrutinee to rebuild original
@@ -138,8 +139,7 @@ mutual
       mkClause fc argpos args (vs ** (clauseEnv, lhs, rhs))
           = do logTerm "unelab.case.clause" 20 "Unelaborating clause" lhs
                let patArgs = snd (getFnArgs lhs)
-                   -- TODO: replace reverse with recalculated argpos
-                   Just pat = idxOrMaybe argpos (reverse patArgs)
+                   Just pat = idxOrMaybe argpos patArgs
                      | _ => pure Nothing
                    rhs = substArgs (mkSizeOf vs) (zip (map argVars patArgs) args) rhs
                logTerm "unelab.case.clause" 20 "Unelaborating LHS" pat
@@ -160,8 +160,7 @@ mutual
       mkCase pats argpos args
           = do unless (null args) $ log "unelab.case.clause" 20 $
                  unwords $ "Ignoring" :: map show (toList $ args)
-               -- TODO: replace reverse with recalculated argpos
-               let Just scrutinee = idxOrMaybe argpos (reverse args)
+               let Just scrutinee = idxOrMaybe argpos args
                      | _ => pure Nothing
                    fc = getLoc scrutinee
                (tm, _) <- unelabTy Full nest env scrutinee


### PR DESCRIPTION
# Description

Fixes
- idris2/basic/basic019
- idris2/basic/basic021
- idris2/basic/basic064
- idris2/casetree/casetree002
- idris2/debug/debug001
- idris2/evaluator/evaluator004
- idris2/interactive/interactive009
- idris2/interactive/interactive016
- idris2/interactive/interactive017
- idris2/literate/literate006
- idris2/misc/docs004
- idris2/misc/lazy003

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

