### PR TITLE
[ fix ] Fix pattern matching on arrow types

### DIFF
--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -759,7 +759,7 @@ groupCons fc fn pvars cs
            then addConG n 0 pargs pats pid rhs acc
            else throw (CaseCompile cfc fn (NotFullyApplied n))
     addGroup (PArrow _ _ s t) pprf pats pid rhs acc
-         = addConG (UN $ Basic "->") 0 [<t, s] pats pid rhs acc
+         = addConG (UN $ Basic "->") 0 [<s, t] pats pid rhs acc
     -- Go inside the delay; we'll flag the case as needing to force its
     -- scrutinee (need to check in 'caseGroups below)
     addGroup (PDelay _ _ pty parg) pprf pats pid rhs acc


### PR DESCRIPTION
# Description

Fixes
- `chez/chez007`
- `idris2/casetree/casetree004`
- `idris2/reg/reg038`
- `node/node007`

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

