### PR TITLE
[ cleanup ] Some cleanup work

### DIFF
--- a/libs/base/Data/SnocList/Operations.idr
+++ b/libs/base/Data/SnocList/Operations.idr
@@ -96,6 +96,17 @@ lengthHomomorphism sx (sy :< x) = Calc $
   ~~ 1 + (length sx + length sy) ...(cong (1+) $ lengthHomomorphism _ _)
   ~~ length sx + (1 + length sy) ...(plusSuccRightSucc _ _)
 
+export
+lengthDistributesOverFish : (sx : SnocList a) -> (ys : List a) ->
+                            length (sx <>< ys) === length sx + length ys
+lengthDistributesOverFish sx [] = sym $ plusZeroRightNeutral _
+lengthDistributesOverFish sx (y :: ys) = Calc $
+  |~ length ((sx :< y) <>< ys)
+  ~~ length (sx :< y) + length ys ...( lengthDistributesOverFish (sx :< y) ys)
+  ~~ S (length sx) + length ys    ...( Refl )
+  ~~ length sx + S (length ys)    ...( plusSuccRightSucc _ _ )
+  ~~ length sx + length (y :: ys) ...( Refl )
+
 -- cons-list operations on snoc-lists
 
 ||| Take `n` first elements from `sx`, returning the whole list if

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -23,12 +23,6 @@ import Libraries.Data.SnocList.Extra
 
 %default covering
 
--- For ease of type level reasoning!
-public export
-rev : SnocList a -> SnocList a
-rev [<] = [<]
-rev (xs :< x) = [<x] ++ rev xs
-
 data Args
     = NewTypeBy Nat Nat
     | EraseArgs Nat (List Nat)

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -18,14 +18,11 @@ import Data.Maybe
 import Data.List
 import Data.SnocList
 import Data.Vect
-import Libraries.Data.List.LengthMatch
+
 import Libraries.Data.NameMap
 import Libraries.Data.WithDefault
-
 import Libraries.Data.List.SizeOf
-import Libraries.Data.SnocList.LengthMatch
 import Libraries.Data.SnocList.SizeOf
-import Libraries.Data.SnocList.HasLength
 import Libraries.Data.SnocList.Extra
 
 %default covering

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -1222,7 +1222,7 @@ mkPat args orig (Ref fc (DataCon t a) n) = pure $ PCon fc n t a (rev args)
 mkPat args orig (Ref fc (TyCon t a) n) = pure $ PTyCon fc n a (rev args)
 mkPat args orig (Ref fc Func n)
   = do prims <- getPrimitiveNames
-       mtm <- normalisePrims (const True) isPConst True prims n args orig [<]
+       mtm <- normalisePrims (const True) isPConst True prims n (cast args) orig [<]
        case mtm of
          Just tm => if tm /= orig -- check we made progress; if there's an
                                   -- unresolved interface, we might be stuck

--- a/src/Core/Case/CaseBuilder.idr
+++ b/src/Core/Case/CaseBuilder.idr
@@ -222,9 +222,9 @@ covering
     where
       showAll : {vs, ts : _} -> NamedPats vs ts -> String
       showAll [] = ""
-      showAll {ts = _ :< t } [x]
+      showAll {ts = _ :< t} [x]
           = show t ++ " " ++ show (pat x) ++ " [" ++ show (argType x) ++ "]"
-      showAll {ts = _ :< t } (x :: xs)
+      showAll {ts = _ :< t} (x :: xs)
           = show t ++ " " ++ show (pat x) ++ " [" ++ show (argType x) ++ "]"
                      ++ ", " ++ showAll xs
 
@@ -233,7 +233,7 @@ covering
     where
       prettyAll : {vs, ts : _} -> NamedPats vs ts -> List (Doc IdrisSyntax)
       prettyAll [] = []
-      prettyAll {ts = _ :< t } (x :: xs)
+      prettyAll {ts = _ :< t} (x :: xs)
           = parens (pretty0 t <++> equals <++> pretty (pat x))
           :: prettyAll xs
 
@@ -597,10 +597,6 @@ updatePatNames _ [] = []
 updatePatNames ns (pi :: ps)
     = { pat $= update } pi :: updatePatNames ns ps
   where
-    lookup : Name -> SnocList (Name, Name) -> Maybe Name
-    lookup n [<] = Nothing
-    lookup n (ns :< (x, n')) = if x == n then Just n' else lookup n ns
-
     update : Pat -> Pat
     update (PAs fc n p)
         = case lookup n ns of

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -195,7 +195,7 @@ export
 covering
 Show Clause where
   show (MkClause {vars} env lhs rhs)
-      = show (toList $ reverse vars) ++ ": " ++ show lhs ++ " = " ++ show rhs
+      = show (asList vars) ++ ": " ++ show lhs ++ " = " ++ show rhs
 
 public export
 data DefFlag

--- a/src/Core/Env.idr
+++ b/src/Core/Env.idr
@@ -78,15 +78,6 @@ bindEnv loc (env :< b) tm
                                         Explicit
                                         (binderType b)) tm)
 
-public export
-revNs : (vs, ns : SnocList a) -> reverse vs ++ reverse ns = reverse (ns ++ vs)
-revNs [<] ns = rewrite appendLinLeftNeutral (reverse ns) in Refl
-revNs (vs :< v) ns
-    = rewrite Extra.revOnto [<v] vs in
-        rewrite Extra.revOnto [<v] (ns ++ vs) in
-          rewrite sym $ revNs vs ns in
-            rewrite appendAssociative [<v] (reverse vs) (reverse ns) in Refl
-
 -- Weaken by all the names at once at the end, to save multiple traversals
 -- in big environments
 -- Also reversing the names at the end saves significant time over concatenating

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -362,7 +362,7 @@ normalisePrims : {auto c : Ref Ctxt Defs} -> {vs : _} ->
                  List Name ->
                  -- view of the potential redex
                  (n : Name) ->          -- function name
-                 (args : SnocList arg) ->   -- arguments from inside out (arg1, ..., argk)
+                 (args : List arg) ->   -- arguments from inside out (arg1, ..., argk)
                  -- actual term to evaluate if needed
                  (tm : Term vs) ->      -- original term (n arg1 ... argk)
                  Env Term vs ->         -- evaluation environment
@@ -371,7 +371,7 @@ normalisePrims : {auto c : Ref Ctxt Defs} -> {vs : _} ->
 normalisePrims boundSafe viewConstant all prims n args tm env
    = do let True = isPrimName prims !(getFullName n) -- is a primitive
               | _ => pure Nothing
-        let (_ :< mc) = reverse args -- with at least one argument
+        let (mc :: _) = args -- with at least one argument
               | _ => pure Nothing
         let (Just c) = viewConstant mc -- that is a constant
               | _ => pure Nothing

--- a/src/Core/SchemeEval/Compile.idr
+++ b/src/Core/SchemeEval/Compile.idr
@@ -97,7 +97,7 @@ reverseOnto acc [<]       = acc
 reverseOnto acc (sx :< x) = reverseOnto (acc :< x) sx
 
 reverse : SchVars vars -> SchVars (reverse vars)
-reverse sx = reverseOnto [<] sx
+reverse = reverseOnto [<]
 
 getSchVar : {idx : _} -> (0 _ : IsVar n idx vars) -> SchVars vars -> String
 getSchVar First (xs :< Bound x) = x

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -460,7 +460,7 @@ tryInstantiate : {auto c : Ref Ctxt Defs} ->
               Term newvars -> -- shrunk environment
               Core Bool -- postpone if the type is yet unknown
 tryInstantiate {newvars} loc mode env mname mref num mdef locs otm tm
-    = do logTerm "unify.instantiate" 5 ("Instantiating in " ++ show !(traverse toFullNames (reverse $ toList newvars))) !(toFullNames tm)
+    = do logTerm "unify.instantiate" 5 ("Instantiating in " ++ show !(traverse toFullNames (asList newvars))) !(toFullNames tm)
 --          let Hole _ _ = definition mdef
 --              | def => ufail {a=()} loc (show mname ++ " already resolved as " ++ show def)
          case fullname mdef of
@@ -473,7 +473,7 @@ tryInstantiate {newvars} loc mode env mname mref num mdef locs otm tm
          logTerm "unify.instantiate" 5 ("Type: " ++ show !(toFullNames mname)) (type mdef)
          logTerm "unify.instantiate" 5 ("Type: " ++ show mname) ty
          log "unify.instantiate" 5 ("With locs: " ++ show locs)
-         log "unify.instantiate" 5 ("From vars: " ++ show (reverse $ toList newvars))
+         log "unify.instantiate" 5 ("From vars: " ++ show (asList newvars))
 
          defs <- get Ctxt
          -- Try to instantiate the hole

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -130,16 +130,6 @@ export
 (++) sx (sy :< y) = (sx ++ sy) :< y
 
 export
-reverseOnto : LocalEnv free varsl -> LocalEnv free varsr -> LocalEnv free (varsl ++ reverse varsr)
-reverseOnto acc Lin       = acc
-reverseOnto {varsr=[<] :< r} acc ([<] :< x) = reverseOnto {varsl=varsl :< r} (acc :< x) [<]
-reverseOnto {varsr=[<] :< vars :< r} acc (sx :< x) = reverseOnto {varsl=varsl :< r} (acc :< x) sx
-
-export
-reverse : LocalEnv free vars -> LocalEnv free (reverse vars)
-reverse {vars} = rewrite sym $ appendLinLeftNeutral (reverse vars) in reverseOnto Lin
-
-export
 cons : LocalEnv free vars -> Closure free -> LocalEnv free (v `cons` vars)
 cons [<] p = Lin :< p
 cons (ns :< s) p = cons ns p :< s

--- a/src/Libraries/Data/SnocList/Extra.idr
+++ b/src/Libraries/Data/SnocList/Extra.idr
@@ -1,6 +1,8 @@
 module Libraries.Data.SnocList.Extra
 
+import Data.Nat
 import Data.SnocList
+import Syntax.PreorderReasoning
 
 public export
 take : (n : Nat) -> (xs : Stream a) -> SnocList a
@@ -33,3 +35,14 @@ export
 lookup : Eq a => a -> SnocList (a, b) -> Maybe b
 lookup n [<] = Nothing
 lookup n (ns :< (x, n')) = if x == n then Just n' else lookup n ns
+
+export
+lengthDistributesOverFish : (sx : SnocList a) -> (ys : List a) ->
+                            length (sx <>< ys) === length sx + length ys
+lengthDistributesOverFish sx [] = sym $ plusZeroRightNeutral _
+lengthDistributesOverFish sx (y :: ys) = Calc $
+  |~ length ((sx :< y) <>< ys)
+  ~~ length (sx :< y) + length ys ...( lengthDistributesOverFish (sx :< y) ys )
+  ~~ S (length sx) + length ys    ...( Refl )
+  ~~ length sx + S (length ys)    ...( plusSuccRightSucc _ _ )
+  ~~ length sx + length (y :: ys) ...( Refl )

--- a/src/Libraries/Data/SnocList/Extra.idr
+++ b/src/Libraries/Data/SnocList/Extra.idr
@@ -28,3 +28,8 @@ revOnto xs (vs :< v)
     = rewrite Extra.revOnto (xs :< v) vs in
         rewrite Extra.revOnto [<v] vs in
           rewrite appendAssociative xs [<v] (reverse vs) in Refl
+
+export
+lookup : Eq a => a -> SnocList (a, b) -> Maybe b
+lookup n [<] = Nothing
+lookup n (ns :< (x, n')) = if x == n then Just n' else lookup n ns

--- a/src/TTImp/Elab/App.idr
+++ b/src/TTImp/Elab/App.idr
@@ -874,7 +874,7 @@ checkApp rig elabinfo nest env fc (IVar fc' n) expargs autoargs namedargs exp
         = do tm <- Normalise.normalisePrims (`boundSafe` elabMode elabinfo)
                                             isIPrimVal
                                             (onLHS (elabMode elabinfo))
-                                            prims n (cast {to=SnocList RawImp} expargs) (fst res) env
+                                            prims n expargs (fst res) env
              pure (fromMaybe (fst res) tm, snd res)
 
       where

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -274,7 +274,7 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
              ty <- getTerm gty
              scriptRet (Just $ map rawName $ !(unelabUniqueBinders env ty))
     elabCon defs "LocalVars" [<]
-        = scriptRet $ reverse $ toList vars
+        = scriptRet $ asList vars
     elabCon defs "GenSym" [<str]
         = do str' <- evalClosure defs str
              n <- genVarName !(reify defs str')

--- a/src/TTImp/ProcessDef.idr
+++ b/src/TTImp/ProcessDef.idr
@@ -394,7 +394,7 @@ checkLHS {vars} trans mult n opts nest env fc lhs_in
 
          lhs <- if trans
                    then pure lhs_bound
-                   else implicitsAs n defs (reverse $ toList vars) lhs_bound
+                   else implicitsAs n defs (asList vars) lhs_bound
 
          logC "declare.def.lhs" 5 $ do pure $ "Checking LHS of " ++ show !(getFullName (Resolved n))
 -- todo: add Pretty RawImp instance

--- a/src/TTImp/Unelab.idr
+++ b/src/TTImp/Unelab.idr
@@ -71,7 +71,7 @@ mutual
                List (Name, Nat) ->
                Env Term vars ->
                Name ->
-               List (Term vars) ->
+               SnocList (Term vars) ->
                Core (Maybe IRawImp)
   unelabCase nest env n args
       = do defs <- get Ctxt
@@ -81,9 +81,8 @@ mutual
                 | _ => pure Nothing
            let Just argpos = findArgPos treect
                 | _ => pure Nothing
-           let len = length args
-           if len == length pargs
-              then mkCase pats (len `minus` argpos + 1) args
+           if length args == length pargs
+              then mkCase pats argpos args
               else pure Nothing
     where
       -- Need to find the position of the scrutinee to rebuild original
@@ -92,13 +91,13 @@ mutual
       findArgPos (Case idx p _ _) = Just idx
       findArgPos _ = Nothing
 
-      idxOrMaybe : Nat -> List a -> Maybe a
-      idxOrMaybe Z (x :: _) = Just x
-      idxOrMaybe (S k) (_ :: xs) = idxOrMaybe k xs
-      idxOrMaybe _ [] = Nothing
+      idxOrMaybe : Nat -> SnocList a -> Maybe a
+      idxOrMaybe Z (_ :< x) = Just x
+      idxOrMaybe (S k) (xs :< _) = idxOrMaybe k xs
+      idxOrMaybe _ [<] = Nothing
 
       -- TODO: some utility like this should probably be implemented in Core
-      substVars : List (List (Var vs), Term vs) -> Term vs -> Term vs
+      substVars : SnocList (List (Var vs), Term vs) -> Term vs -> Term vs
       substVars xs tm@(Local fc _ idx prf)
           = case find (any ((idx ==) . varIdx) . fst) xs of
                  Just (_, new) => new
@@ -119,13 +118,11 @@ mutual
           = TForce fc r (substVars xs y)
       substVars xs tm = tm
 
-      substArgs : SizeOf vs -> List (List (Var vs), Term vars) -> Term vs -> Term (vars ++ vs)
+      substArgs : SizeOf vs -> SnocList (List (Var vs), Term vars) -> Term vs -> Term (vars ++ vs)
       substArgs p substs tm =
-        let
-          substs' = map (bimap (map embed) (weakenNs p)) substs
-          tm' = embed tm
-        in
-          substVars substs' tm'
+        let substs' = map (bimap (map embed) (weakenNs p)) substs
+            tm' = embed tm
+         in substVars substs' tm'
 
       argVars : {vs : _} -> Term vs -> List (Var vs)
       argVars (As _ _ as pat) = argVars as ++ argVars pat
@@ -133,12 +130,12 @@ mutual
       argVars _ = []
 
       mkClause : FC -> Nat ->
-                 List (Term vars) ->
+                 SnocList (Term vars) ->
                  (vs ** (Env Term vs, Term vs, Term vs)) ->
                  Core (Maybe IImpClause)
       mkClause fc argpos args (vs ** (clauseEnv, lhs, rhs))
           = do logTerm "unelab.case.clause" 20 "Unelaborating clause" lhs
-               let patArgs = snd (getFnArgs lhs)
+               let patArgs = snd (getFnArgsSpine lhs)
                    Just pat = idxOrMaybe argpos patArgs
                      | _ => pure Nothing
                    rhs = substArgs (mkSizeOf vs) (zip (map argVars patArgs) args) rhs
@@ -156,7 +153,7 @@ mutual
       ||| Once we have the scrutinee `e`, we can form `case e of` and so focus
       ||| on manufacturing the clauses.
       mkCase : List (vs ** (Env Term vs, Term vs, Term vs)) ->
-               (argpos : Nat) -> List (Term vars) -> Core (Maybe IRawImp)
+               (argpos : Nat) -> SnocList (Term vars) -> Core (Maybe IRawImp)
       mkCase pats argpos args
           = do unless (null args) $ log "unelab.case.clause" 20 $
                  unwords $ "Ignoring" :: map show (toList $ args)
@@ -272,7 +269,7 @@ mutual
               case umode of
                 (NoSugar _) => pure Nothing
                 ImplicitHoles => pure Nothing
-                _ => case getFnArgs tm of
+                _ => case getFnArgsSpine tm of
                      (Ref _ _ fnName, args) => do
                        fullName <- getFullName fnName
                        let (NS ns (CaseBlock n i)) = fullName


### PR DESCRIPTION
# Description

1. In the `unelabCase` and `normalisePrims` signatures, replaced `List` with `SnocList` for a more natural implementation
2. Make `LengthMatch` arguments erased
3. Move some utility functions into `Libraries`
4. Remove some unused functions and import
5. Complete proof in `LambdaLift.idr`
6. Remove redudant casts in `Normalise.idr`

## Should this change go in the CHANGELOG?

<!-- Please delete this section if it doesn't apply -->
- [ ] If this is a fix, user-facing change, a compiler change, or a new paper
      implementation, I have updated [`CHANGELOG_NEXT.md`](https://github.com/idris-lang/Idris2/blob/main/CHANGELOG_NEXT.md) (and potentially also
      `CONTRIBUTORS.md`).

