### PR TITLE
Scoped snoc list preparing review

### DIFF
--- a/libs/base/Data/List/Quantifiers.idr
+++ b/libs/base/Data/List/Quantifiers.idr
@@ -91,6 +91,14 @@ namespace All
   imapProperty i f @{[]} [] = []
   imapProperty i f @{ix :: ixs} (x :: xs) = f @{ix} x :: imapProperty i f @{ixs} xs
 
+  export
+  head : All p (x :: xs) -> p x
+  head (px :: _) = px
+
+  export
+  tail : All p (x :: xs) -> All p xs
+  tail (_ :: pxs) = pxs
+
   ||| Forget property source for a homogeneous collection of properties
   public export
   forget : All (const type) types -> List type

--- a/libs/base/Data/SnocList/HasLength.idr
+++ b/libs/base/Data/SnocList/HasLength.idr
@@ -29,9 +29,13 @@ map f Z = Z
 map f (S hl) = S (map f hl)
 
 export
-sucR : HasLength n sx -> HasLength (S n) ([<x] ++ sx)
-sucR Z     = S Z
-sucR (S n) = S (sucR n)
+sucL : HasLength n sx -> HasLength (S n) ([<x] ++ sx)
+sucL Z     = S Z
+sucL (S n) = S (sucL n)
+
+export
+sucR : HasLength n sx -> HasLength (S n) (sx ++ [<x])
+sucR = S
 
 export
 hlAppend : HasLength m sx -> HasLength n sy -> HasLength (n + m) (sx ++ sy)

--- a/src/Compiler/ANF.idr
+++ b/src/Compiler/ANF.idr
@@ -8,6 +8,7 @@ import Core.Core
 import Core.TT
 
 import Data.List
+import Data.List.Quantifiers
 import Data.SnocList
 import Data.Vect
 import Libraries.Data.SortedSet
@@ -138,12 +139,8 @@ Show ANFDef where
         show args ++ " -> " ++ show ret
   show (MkAError exp) = "Error: " ++ show exp
 
-data AVars : Scoped where
-     Nil : AVars ScopeEmpty
-     (::) : Int -> AVars xs -> AVars (x :: xs)
-
-ScopeEmpty : AVars ScopeEmpty
-ScopeEmpty = []
+AVars : Scope -> Type
+AVars = All (\_ => Int)
 
 data Next : Type where
 
@@ -285,7 +282,7 @@ toANF (MkLCon t a ns) = pure $ MkACon t a ns
 toANF (MkLForeign ccs fargs t) = pure $ MkAForeign ccs fargs t
 toANF (MkLError err)
     = do v <- newRef Next (the Int 0)
-         pure $ MkAError !(anf ScopeEmpty err)
+         pure $ MkAError !(anf [] err)
 
 export
 freeVariables : ANF -> SortedSet AVar

--- a/src/Compiler/CaseOpts.idr
+++ b/src/Compiler/CaseOpts.idr
@@ -113,7 +113,7 @@ liftOutLambda : {args : _} ->
                 (new : Name) ->
                 CExp (old :: args ++ vars) ->
                 CExp (args ++ new :: vars)
-liftOutLambda = shiftBinder {outer = ScopeEmpty}
+liftOutLambda = shiftBinder {outer = Scope.empty}
 
 -- If all the alternatives start with a lambda, we can have a single lambda
 -- binding outside

--- a/src/Compiler/Common.idr
+++ b/src/Compiler/Common.idr
@@ -153,7 +153,7 @@ getMinimalDef (Coded ns bin)
          name <- fromBuf b
          let def
              = MkGlobalDef fc name (Erased fc Placeholder) [] [] [] [] mul
-                           ScopeEmpty (specified Public) (MkTotality Unchecked IsCovering) False
+                           Scope.empty (specified Public) (MkTotality Unchecked IsCovering) False
                            [] Nothing refsR False False True
                            None cdef Nothing [] Nothing
          pure (def, Just (ns, bin))
@@ -355,7 +355,7 @@ getCompileDataWith exports doLazyAnnots phase_in tm_in
                               traverse (lambdaLift doLazyAnnots) cseDefs
                          else pure []
 
-         let lifted = (mainname, MkLFun ScopeEmpty ScopeEmpty liftedtm) ::
+         let lifted = (mainname, MkLFun Scope.empty Scope.empty liftedtm) ::
                       (ldefs ++ concat lifted_in)
 
          anf <- if phase >= ANF

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -13,6 +13,7 @@ import Core.TT
 import Core.Value
 
 import Data.List
+import Data.List.HasLength
 import Data.SnocList
 import Data.Maybe
 import Data.Vect
@@ -324,7 +325,7 @@ mutual
     where
       mkSubst : Nat -> CExp vs ->
                 Nat -> (args : List Name) -> (SizeOf args, SubstCEnv args vs)
-      mkSubst _ _ _ [] = (zero, ScopeEmpty)
+      mkSubst _ _ _ [] = (zero, Subst.empty)
       mkSubst i scr pos (a :: as)
           = let (s, env) = mkSubst (1 + i) scr pos as in
             if i == pos
@@ -391,15 +392,19 @@ mutual
 
 -- Need this for ensuring that argument list matches up to operator arity for
 -- builtins
-data ArgList : Nat -> Scope -> Type where
-     NoArgs : ArgList Z ScopeEmpty
-     ConsArg : (a : Name) -> ArgList k as -> ArgList (S k) (a :: as)
+ArgList : Nat -> Scope -> Type
+ArgList = HasLength
 
 mkArgList : Int -> (n : Nat) -> (ns ** ArgList n ns)
-mkArgList i Z = (_ ** NoArgs)
+mkArgList i Z = (_ ** Z)
 mkArgList i (S k)
-    = let (_ ** rec) = mkArgList (i + 1) k in
-          (_ ** ConsArg (MN "arg" i) rec)
+    = let (ns ** rec) = mkArgList (i + 1) k in
+          ((MN "arg" i) :: ns ** S rec)
+
+-- TODO has quadratic runtime
+getVars : ArgList k ns -> Vect k (Var ns)
+getVars Z = []
+getVars (S rest) = MkVar First :: map weakenVar (getVars rest)
 
 data NArgs : Type where
      User : Name -> List ClosedClosure -> NArgs
@@ -474,7 +479,7 @@ nfToCFType _ _ (NPrimVal _ $ PrT WorldType) = pure CFWorld
 nfToCFType _ False (NBind fc _ (Pi _ _ _ ty) sc)
     = do defs <- get Ctxt
          sty <- nfToCFType fc False !(evalClosure defs ty)
-         sc' <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+         sc' <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
          tty <- nfToCFType fc False sc'
          pure (CFFun sty tty)
 nfToCFType _ True (NBind fc _ _ _)
@@ -509,7 +514,7 @@ nfToCFType _ s (NErased _ _)
     = pure (CFUser (UN (Basic "__")) [])
 nfToCFType fc s t
     = do defs <- get Ctxt
-         ty <- quote defs ScopeEmpty t
+         ty <- quote defs Env.empty t
          throw (GenericMsg (getLoc t)
                        ("Can't marshal type for foreign call " ++
                                       show !(toFullNames ty)))
@@ -520,13 +525,13 @@ getCFTypes : {auto c : Ref Ctxt Defs} ->
 getCFTypes args (NBind fc _ (Pi _ _ _ ty) sc)
     = do defs <- get Ctxt
          aty <- nfToCFType fc False !(evalClosure defs ty)
-         sc' <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+         sc' <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
          getCFTypes (aty :: args) sc'
 getCFTypes args t
     = pure (reverse args, !(nfToCFType (getLoc t) False t))
 
-lamRHSenv : Int -> FC -> (ns : Scope) -> (SizeOf ns, SubstCEnv ns ScopeEmpty)
-lamRHSenv i fc [] = (zero, ScopeEmpty)
+lamRHSenv : Int -> FC -> (ns : Scope) -> (SizeOf ns, SubstCEnv ns Scope.empty)
+lamRHSenv i fc [] = (zero, Subst.empty)
 lamRHSenv i fc (n :: ns)
     = let (s, env) = lamRHSenv (i + 1) fc ns in
       (suc s, CRef fc (MN "x" i) :: env)
@@ -551,12 +556,15 @@ lamRHS ns tm
           tmExp = substs s env (rewrite appendNilRightNeutral ns in tm)
           newArgs = reverse $ getNewArgs env
           bounds = mkBounds newArgs
-          expLocs = mkLocals zero {vars = ScopeEmpty} bounds tmExp in
+          expLocs = mkLocals zero {vars = Scope.empty} bounds tmExp in
           lamBind (getFC tm) _ expLocs
   where
     lamBind : FC -> (ns : Scope) -> CExp ns -> ClosedCExp
     lamBind fc [] tm = tm
     lamBind fc (n :: ns) tm = lamBind fc ns (CLam fc n tm)
+
+toArgExp : (Var ns) -> CExp ns
+toArgExp (MkVar p) = CLocal emptyFC p
 
 toCDef : Ref Ctxt Defs => Ref NextMN Int =>
          Name -> ClosedTerm -> List Nat -> Def ->
@@ -571,36 +579,24 @@ toCDef n ty erased (PMDef pi args _ tree _)
             else MkFun args' (shrinkCExp p comptree)
   where
     toLam : Bool -> CDef -> CDef
-    toLam True (MkFun args rhs) = MkFun ScopeEmpty (lamRHS args rhs)
+    toLam True (MkFun args rhs) = MkFun Scope.empty (lamRHS args rhs)
     toLam _ d = d
 toCDef n ty _ (ExternDef arity)
     = let (ns ** args) = mkArgList 0 arity in
-          pure $ MkFun _ (CExtPrim emptyFC !(getFullName n) (map toArgExp (getVars args)))
-  where
-    toArgExp : (Var ns) -> CExp ns
-    toArgExp (MkVar p) = CLocal emptyFC p
+          pure $ MkFun _ (CExtPrim emptyFC !(getFullName n) (map toArgExp (toList $ getVars args)))
 
-    getVars : ArgList k ns -> List (Var ns)
-    getVars NoArgs = []
-    getVars (ConsArg a rest) = MkVar First :: map weakenVar (getVars rest)
 toCDef n ty _ (ForeignDef arity cs)
     = do defs <- get Ctxt
-         (atys, retty) <- getCFTypes [] !(nf defs ScopeEmpty ty)
+         (atys, retty) <- getCFTypes [] !(nf defs Env.empty ty)
          pure $ MkForeign cs atys retty
 toCDef n ty _ (Builtin {arity} op)
     = let (ns ** args) = mkArgList 0 arity in
           pure $ MkFun _ (COp emptyFC op (map toArgExp (getVars args)))
-  where
-    toArgExp : (Var ns) -> CExp ns
-    toArgExp (MkVar p) = CLocal emptyFC p
 
-    getVars : ArgList k ns -> Vect k (Var ns)
-    getVars NoArgs = []
-    getVars (ConsArg a rest) = MkVar First :: map weakenVar (getVars rest)
 toCDef n _ _ (DCon tag arity pos)
     = do let nt = snd <$> pos
          defs <- get Ctxt
-         args <- numArgs {vars = ScopeEmpty} defs (Ref EmptyFC (DataCon tag arity) n)
+         args <- numArgs {vars = Scope.empty} defs (Ref EmptyFC (DataCon tag arity) n)
          let arity' = case args of
                  NewTypeBy ar _ => ar
                  EraseArgs ar erased => ar `minus` length erased

--- a/src/Compiler/CompileExpr.idr
+++ b/src/Compiler/CompileExpr.idr
@@ -482,7 +482,7 @@ nfToCFType _ True (NBind fc _ _ _)
 nfToCFType _ s (NTCon fc n_in _ _ args)
     = do defs <- get Ctxt
          n <- toFullNames n_in
-         case !(getNArgs defs n $ toList (map snd args)) of
+         case !(getNArgs defs n $ map snd args) of
               User un uargs =>
                 do nargs <- traverse (evalClosure defs) uargs
                    cargs <- traverse (nfToCFType fc s) nargs

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -33,7 +33,7 @@ EEnv : Scope -> Scope -> Type
 EEnv free = All (\_ => CExp free)
 
 extend : EEnv free vars -> (args : List (CExp free)) -> (args' : List Name) ->
-         LengthMatch args args' -> EEnv free (AddInner vars args')
+         LengthMatch args args' -> EEnv free (Scope.addInner vars args')
 extend env [] [] NilMatch = env
 extend env (a :: xs) (n :: ns) (ConsMatch w)
     = a :: extend env xs ns w
@@ -55,7 +55,7 @@ getArity (MkForeign _ args _) = length args
 getArity (MkError _) = 0
 
 takeFromStack : EEnv free vars -> Stack free -> (args : Scope) ->
-                Maybe (EEnv free (AddInner vars args), Stack free)
+                Maybe (EEnv free (Scope.addInner vars args), Stack free)
 takeFromStack env (e :: es) (a :: as)
   = do (env', stk') <- takeFromStack env es as
        pure (e :: env', stk')

--- a/src/Compiler/Inline.idr
+++ b/src/Compiler/Inline.idr
@@ -32,11 +32,11 @@ data EEnv : Scope -> Scope -> Type where
      Nil : EEnv free ScopeEmpty
      (::) : CExp free -> EEnv free vars -> EEnv free (x :: vars)
 public export
-ScopeEmpty : {tm: _} -> EEnv tm ScopeEmpty
+ScopeEmpty : EEnv tm ScopeEmpty
 ScopeEmpty = []
 
 extend : EEnv free vars -> (args : List (CExp free)) -> (args' : List Name) ->
-         LengthMatch args args' -> EEnv free (args' ++ vars)
+         LengthMatch args args' -> EEnv free (AddInner vars args')
 extend env [] [] NilMatch = env
 extend env (a :: xs) (n :: ns) (ConsMatch w)
     = a :: extend env xs ns w
@@ -58,7 +58,7 @@ getArity (MkForeign _ args _) = length args
 getArity (MkError _) = 0
 
 takeFromStack : EEnv free vars -> Stack free -> (args : Scope) ->
-                Maybe (EEnv free (args ++ vars), Stack free)
+                Maybe (EEnv free (AddInner vars args), Stack free)
 takeFromStack env (e :: es) (a :: as)
   = do (env', stk') <- takeFromStack env es as
        pure (e :: env', stk')
@@ -433,6 +433,7 @@ mkBounds : (xs : _) -> Bounds xs
 mkBounds [] = None
 mkBounds (x :: xs) = Add x x (mkBounds xs)
 
+-- TODO `getNewArgs` is always used in reverse, revisit!
 getNewArgs : {done : _} ->
              SubstCEnv done args -> Scope
 getNewArgs [] = []

--- a/src/Compiler/Interpreter/VMCode.idr
+++ b/src/Compiler/Interpreter/VMCode.idr
@@ -113,7 +113,7 @@ indexMaybe (x :: xs) idx = if idx <= 0 then Just x else indexMaybe xs (idx - 1)
 callPrim : Ref State InterpState => Stack -> PrimFn ar -> Vect ar Object -> Core Object
 callPrim stk BelieveMe [_, _, obj] = pure obj
 callPrim stk fn args = case the (Either Object (Vect ar Constant)) $ traverse getConst args of
-    Right args' => case getOp {vars=ScopeEmpty} fn (NPrimVal EmptyFC <$> args') of
+    Right args' => case getOp {vars=Scope.empty} fn (NPrimVal EmptyFC <$> args') of
         Just (NPrimVal _ res) => pure $ Const res
         _ => interpError stk $ "OP: Error calling " ++ show (opName fn) ++ " with operands: " ++ show args'
     Left obj => interpError stk $ "OP: Expected Constant, found " ++ showType obj

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -229,7 +229,7 @@ data LiftedDef : Type where
      -- arranged for the variables, and it could be expensive to reshuffle them!
      -- See Compiler.ANF for an example of how they get resolved to names)
      MkLFun : (args : Scope) -> (scope : Scope) ->
-              (body : Lifted (AddInner args scope)) -> LiftedDef
+              (body : Lifted (Scope.addInner args scope)) -> LiftedDef
 
      ||| Constructs a definition of a constructor for a compound data type.
      |||
@@ -423,7 +423,7 @@ usedVars used (LUnderApp fc n miss args) =
 usedVars used (LApp fc lazy c arg) =
   usedVars (usedVars used arg) c
 usedVars used (LLet fc x val sc) =
-  let innerUsed = contractUsed $ usedVars (weakenUsed {outer=ScopeSingle x} used) sc in
+  let innerUsed = contractUsed $ usedVars (weakenUsed {outer=Scope.single x} used) sc in
       usedVars innerUsed val
 usedVars used (LCon fc n ci tag args) =
   foldl (usedVars {vars}) used args
@@ -560,7 +560,7 @@ mutual
             CExp vars -> Core (Lifted vars)
   liftExp (CLocal fc prf) = pure $ LLocal fc prf
   liftExp (CRef fc n) = pure $ LAppName fc lazy n [] -- probably shouldn't happen!
-  liftExp (CLam fc x sc) = makeLam {doLazyAnnots} {lazy} fc (ScopeSingle x) sc
+  liftExp (CLam fc x sc) = makeLam {doLazyAnnots} {lazy} fc (Scope.single x) sc
   liftExp (CLet fc x _ val sc) = pure $ LLet fc x !(liftExp {doLazyAnnots} val) !(liftExp {doLazyAnnots} sc)
   liftExp (CApp fc (CRef _ n) args) -- names are applied exactly in compileExp
       = pure $ LAppName fc lazy n !(traverse (liftExp {doLazyAnnots}) args)

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -173,7 +173,7 @@ mutual
   ||| @ vars is the list of names accessible within the current scope of the
   |||   lambda-lifted code.
   public export
-  data LiftedConAlt : (vars : Scope) -> Type where
+  data LiftedConAlt : Scoped where
 
        ||| Constructs a branch of an "LCon" (constructor tag) case statement.
        |||
@@ -199,7 +199,7 @@ mutual
   ||| @ vars is the list of names accessible within the current scope of the
   |||   lambda-lifted code.
   public export
-  data LiftedConstAlt : (vars : Scope) -> Type where
+  data LiftedConstAlt : Scoped where
 
        ||| Constructs a branch of an "LConst" (constant expression) case
        ||| statement.
@@ -229,7 +229,7 @@ data LiftedDef : Type where
      -- arranged for the variables, and it could be expensive to reshuffle them!
      -- See Compiler.ANF for an example of how they get resolved to names)
      MkLFun : (args : Scope) -> (scope : Scope) ->
-              (body : Lifted (scope ++ args)) -> LiftedDef
+              (body : Lifted (AddInner args scope)) -> LiftedDef
 
      ||| Constructs a definition of a constructor for a compound data type.
      |||
@@ -360,8 +360,9 @@ record Used (vars : Scope) where
 initUsed : {vars : _} -> Used vars
 initUsed {vars} = MkUsed (replicate (length vars) False)
 
+-- TODO upstream
 lengthDistributesOverAppend
-  : (xs, ys : Scopeable a)
+  : (xs, ys : List a)
   -> length (xs ++ ys) = length xs + length ys
 lengthDistributesOverAppend [] ys = Refl
 lengthDistributesOverAppend (x :: xs) ys =

--- a/src/Compiler/LambdaLift.idr
+++ b/src/Compiler/LambdaLift.idr
@@ -262,7 +262,7 @@ data LiftedDef : Type where
      ||| `LCrash` rather than `prim_crash`.
      |||
      ||| @ expl : an explanation of the error.
-     MkLError : (expl : Lifted ScopeEmpty) -> LiftedDef
+     MkLError : (expl : Lifted Scope.empty) -> LiftedDef
 
 showLazy : Maybe LazyReason -> String
 showLazy = maybe "" $ (" " ++) . show
@@ -462,8 +462,8 @@ dropIdx : {vars : _} ->
 dropIdx [] (False::_) First = MkVar First
 dropIdx [] (True::_) First = assert_total $
   idris_crash "INTERNAL ERROR: Referenced variable marked as unused"
-dropIdx [] (False::rest) (Later p) = Var.later $ dropIdx ScopeEmpty rest p
-dropIdx [] (True::rest) (Later p) = dropIdx ScopeEmpty rest p
+dropIdx [] (False::rest) (Later p) = Var.later $ dropIdx Scope.empty rest p
+dropIdx [] (True::rest) (Later p) = dropIdx Scope.empty rest p
 dropIdx (_::xs) unused First = MkVar First
 dropIdx (_::xs) unused (Later p) = Var.later $ dropIdx xs unused p
 
@@ -611,7 +611,7 @@ export
 lambdaLiftDef : (doLazyAnnots : Bool) -> Name -> CDef -> Core (List (Name, LiftedDef))
 lambdaLiftDef doLazyAnnots n (MkFun args exp)
     = do (expl, defs) <- liftBody {doLazyAnnots} n exp
-         pure ((n, MkLFun args ScopeEmpty expl) :: defs)
+         pure ((n, MkLFun args Scope.empty expl) :: defs)
 lambdaLiftDef _ n (MkCon t a nt) = pure [(n, MkLCon t a nt)]
 lambdaLiftDef _ n (MkForeign ccs fargs ty) = pure [(n, MkLForeign ccs fargs ty)]
 lambdaLiftDef doLazyAnnots n (MkError exp)

--- a/src/Compiler/Opts/CSE.idr
+++ b/src/Compiler/Opts/CSE.idr
@@ -206,7 +206,7 @@ mutual
 
   analyze exp = do
     (sze, exp') <- analyzeSubExp exp
-    case dropEnv {pre = ScopeEmpty} exp' of
+    case dropEnv {pre = Scope.empty} exp' of
       Just e0 => do
         Just nm <- store sze e0
           | Nothing => pure (sze, exp')
@@ -477,8 +477,8 @@ replaceDef (n, fc, d@(MkError _))       = pure (n, fc, d)
 newToplevelDefs : ReplaceMap -> List (Name, FC, CDef)
 newToplevelDefs rm = mapMaybe toDef $ SortedMap.toList rm
   where toDef : (Name,(ClosedCExp,Count,Bool)) -> Maybe (Name, FC, CDef)
-        toDef (nm,(exp,Many,False)) = Just (nm, EmptyFC, MkFun ScopeEmpty exp)
-        toDef (nm,(exp,Many,True)) = Just (nm, EmptyFC, MkFun ScopeEmpty (CDelay EmptyFC LLazy exp))
+        toDef (nm,(exp,Many,False)) = Just (nm, EmptyFC, MkFun Scope.empty exp)
+        toDef (nm,(exp,Many,True)) = Just (nm, EmptyFC, MkFun Scope.empty (CDelay EmptyFC LLazy exp))
         toDef _               = Nothing
 
 undefinedCount : (Name, (ClosedCExp, Count)) -> Bool

--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -98,7 +98,7 @@ constFold : {vars' : _} ->
 constFold rho (CLocal fc p) = lookup fc (MkVar p) rho
 constFold rho e@(CRef fc x) = CRef fc x
 constFold rho (CLam fc x y)
-  = CLam fc x $ constFold (wk (mkSizeOf (ScopeSingle x)) rho) y
+  = CLam fc x $ constFold (wk (mkSizeOf (Scope.single x)) rho) y
 
 -- Expressions of the type `let x := y in x` can be introduced
 -- by the compiler when inlining monadic code (for instance, `io_bind`).
@@ -107,7 +107,7 @@ constFold rho (CLet fc x inl y z) =
     let val := constFold rho y
      in case replace val of
           True  => constFold (val::rho) z
-          False => case constFold (wk (mkSizeOf (ScopeSingle x)) rho) z of
+          False => case constFold (wk (mkSizeOf (Scope.single x)) rho) z of
             CLocal {idx = 0} _ _ => val
             body                 => CLet fc x inl val body
 constFold rho (CApp fc (CRef fc2 n) [x]) =

--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -31,18 +31,20 @@ foldableOp _                = True
 
 
 data Subst : Scope -> Scoped where
-  Nil  : Subst ScopeEmpty vars
+  Nil  : Subst Scope.empty vars
   (::) : CExp vars -> Subst ds vars -> Subst (d :: ds) vars
   Wk   : SizeOf ws -> Subst ds vars -> Subst (ws ++ ds) (ws ++ vars)
 
-ScopeEmpty : Subst ScopeEmpty vars
-ScopeEmpty = []
+namespace Subst
+  public export
+  empty : Subst Scope.empty vars
+  empty = []
 
 initSubst : (vars : Scope) -> Subst vars vars
+initSubst [] = Subst.empty
 initSubst vars
   = rewrite sym $ appendNilRightNeutral vars in
-    Wk (mkSizeOf vars) ScopeEmpty
-
+    Wk (mkSizeOf vars) Subst.empty
 
 wk : SizeOf out -> Subst ds vars -> Subst (out ++ ds) (out ++ vars)
 wk sout (Wk {ws, ds, vars} sws rho)

--- a/src/Compiler/Opts/ConstantFold.idr
+++ b/src/Compiler/Opts/ConstantFold.idr
@@ -30,7 +30,7 @@ foldableOp (Cast from to)   = isJust (intKind from) && isJust (intKind to)
 foldableOp _                = True
 
 
-data Subst : Scope -> Scope -> Type where
+data Subst : Scope -> Scoped where
   Nil  : Subst ScopeEmpty vars
   (::) : CExp vars -> Subst ds vars -> Subst (d :: ds) vars
   Wk   : SizeOf ws -> Subst ds vars -> Subst (ws ++ ds) (ws ++ vars)

--- a/src/Compiler/Opts/Identity.idr
+++ b/src/Compiler/Opts/Identity.idr
@@ -118,7 +118,7 @@ checkIdentity fn (v :: vs) exp idx = if cexpIdentity fn idx v Nothing Nothing ex
     else checkIdentity fn vs exp (S idx)
 
 calcIdentity : (fullName : Name) -> CDef -> Maybe Nat
-calcIdentity fn (MkFun args exp) = checkIdentity fn (makeArgs {vars=ScopeEmpty} args) (rewrite appendNilRightNeutral args in exp) Z
+calcIdentity fn (MkFun args exp) = checkIdentity fn (makeArgs {vars=Scope.empty} args) (rewrite appendNilRightNeutral args in exp) Z
 calcIdentity _ _ = Nothing
 
 getArg : FC -> Nat -> (args : Scope) -> Maybe (CExp args)

--- a/src/Compiler/Opts/Identity.idr
+++ b/src/Compiler/Opts/Identity.idr
@@ -10,6 +10,7 @@ import Data.Vect
 import Libraries.Data.List.SizeOf
 import Libraries.Data.SnocList.SizeOf
 
+-- TODO reduce quadratic weakening
 makeArgs : (args : Scope) -> List (Var (args ++ vars))
 makeArgs args = makeArgs' args id
   where

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -231,7 +231,7 @@ usableLocal loc defaults env (NApp fc (NMeta _ _ _) args)
     = pure False
 usableLocal {vars} loc defaults env (NTCon _ n _ _ args)
     = do sd <- getSearchData loc (not defaults) n
-         usableLocalArg 0 (detArgs sd) (toList $ map snd args)
+         usableLocalArg 0 (detArgs sd) (map snd args)
   -- usable if none of the determining arguments of the local's type are
   -- holes
   where
@@ -509,13 +509,13 @@ checkConcreteDets fc defaults env top (NTCon tfc tyn t a args)
                              checkConcreteDets fc defaults env top anf
                              checkConcreteDets fc defaults env top bnf
                       _ => do sd <- getSearchData fc defaults tyn
-                              concreteDets fc defaults env top 0 (detArgs sd) (toList $ map snd args)
+                              concreteDets fc defaults env top 0 (detArgs sd) (map snd args)
             else
               do sd <- getSearchData fc defaults tyn
                  log "auto.determining" 10 $
                    "Determining arguments for " ++ show !(toFullNames tyn)
                    ++ " " ++ show (detArgs sd)
-                 concreteDets fc defaults env top 0 (detArgs sd) (toList $ map snd args)
+                 concreteDets fc defaults env top 0 (detArgs sd) (map snd args)
 checkConcreteDets fc defaults env top _
     = pure ()
 

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -105,18 +105,18 @@ searchIfHole : {vars : _} ->
                (arg : ArgInfo vars) ->
                Core ()
 searchIfHole fc defaults trying ispair Z def top env arg
-    = throw (CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing) -- possibly should say depth limit hit?
+    = throw (CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing) -- possibly should say depth limit hit?
 searchIfHole fc defaults trying ispair (S depth) def top env arg
     = do let hole = holeID arg
          let rig = argRig arg
 
          defs <- get Ctxt
          Just gdef <- lookupCtxtExact (Resolved hole) (gamma defs)
-              | Nothing => throw (CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing)
+              | Nothing => throw (CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing)
          let Hole _ _ = definition gdef
               | _ => pure () -- already solved
          top' <- if ispair
-                    then normaliseScope defs ScopeEmpty (type gdef)
+                    then normaliseScope defs Env.empty (type gdef)
                     else pure top
 
          argdef <- searchType fc rig defaults trying depth def False top' env
@@ -128,7 +128,7 @@ searchIfHole fc defaults trying ispair (S depth) def top env arg
             then pure ()
             else do vs <- unify inTerm fc env (metaApp arg) argdef
                     let [] = constraints vs
-                        | _ => throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                        | _ => throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
                     pure ()
 
 successful : {vars : _} ->
@@ -162,13 +162,13 @@ anyOne : {vars : _} ->
          FC -> Env Term vars -> (topTy : ClosedTerm) ->
          List (Core (Term vars)) ->
          Core (Term vars)
-anyOne fc env top [] = throw (CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing)
+anyOne fc env top [] = throw (CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing)
 anyOne fc env top [elab]
     = catch elab $
          \case
            err@(CantSolveGoal _ _ _ _ _) => throw err
            err@(AmbiguousSearch _ _ _ _) => throw err
-           _ => throw $ CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing
+           _ => throw $ CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing
 anyOne fc env top (elab :: elabs)
     = tryUnify elab (anyOne fc env top elabs)
 
@@ -182,7 +182,7 @@ exactlyOne fc env top target [elab]
     = catch elab $
          \case
            err@(CantSolveGoal _ _ _ _ _) => throw err
-           _ => throw $ CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing
+           _ => throw $ CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing
 exactlyOne {vars} fc env top target all
     = do elabs <- successful all
          case nubBy ((==) `on` fst) $ rights elabs of
@@ -191,7 +191,7 @@ exactlyOne {vars} fc env top target all
                        put Ctxt defs
                        commit
                        pure res
-              [] => throw (CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing)
+              [] => throw (CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing)
               rs => throw (AmbiguousSearch fc env !(quote !(get Ctxt) env target)
                              !(traverse normRes rs))
   where
@@ -207,6 +207,7 @@ getUsableEnv : {vars : _} ->
                 FC -> RigCount ->
                 SizeOf done ->
                 Env Term vars ->
+                -- TODO this will be `vars <>< done` after refactoring
                 List (Term (done ++ vars), Term (done ++ vars))
 getUsableEnv fc rigc p [] = []
 getUsableEnv {vars = v :: vs} {done} fc rigc p (b :: env)
@@ -300,7 +301,7 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
              logNF "auto" 10 "For target" env target
              ures <- unify inTerm fc env target appTy
              let [] = constraints ures
-                 | _ => throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                 | _ => throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
              -- We can only use the local if its type is not an unsolved hole
              if !(usableLocal fc defaults env ty)
                 then do
@@ -315,7 +316,7 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
                             (impLast args)
                    pure candidate
                 else do logNF "auto" 10 "Can't use " env ty
-                        throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                        throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
 
     findPos : Defs ->
               (Term vars -> Core (Term vars)) ->
@@ -324,10 +325,10 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
               Core (Term vars)
     findPos defs f nty@(NTCon pfc pn _ _ [(_, xty), (_, yty)]) target
         = tryUnifyUnambig (findDirect defs f nty target) $
-             do fname <- maybe (throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing))
+             do fname <- maybe (throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing))
                                pure
                                !fstName
-                sname <- maybe (throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing))
+                sname <- maybe (throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing))
                                pure
                                !sndName
                 if !(isPairType pn)
@@ -349,7 +350,7 @@ searchLocalWith {vars} fc rigc defaults trying depth def top env (prf, ty) targe
                                                          ytytm,
                                                          !(f arg)])
                                      ytynf target)]
-                   else throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                   else throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
     findPos defs f nty target
         = findDirect defs f nty target
 
@@ -390,9 +391,9 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
     = do defs <- get Ctxt
          when (not (visibleInAny (!getNS :: !getNestedNS)
                                  (fullname ndef) (collapseDefault $ visibility ndef))) $
-            throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+            throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
          when (BlockedHint `elem` flags ndef) $
-            throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+            throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
 
          let ty = type ndef
          let namety : NameType
@@ -405,7 +406,7 @@ searchName fc rigc defaults trying depth def top env target (n, ndef)
          (args, appTy) <- mkArgs fc rigc env nty
          ures <- unify inTerm fc env target appTy
          let [] = constraints ures
-             | _ => throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+             | _ => throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
          ispair <- isPairNF env nty defs
          let candidate = apply fc (Ref fc namety n) (map metaApp args)
          logTermNF "auto" 10 "Candidate " env candidate
@@ -425,7 +426,7 @@ searchNames : {vars : _} ->
               Env Term vars -> Bool -> List Name ->
               (target : NF vars) -> Core (Term vars)
 searchNames fc rigc defaults trying depth defining topty env ambig [] target
-    = throw (CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty topty Nothing)
+    = throw (CantSolveGoal fc (gamma !(get Ctxt)) Env.empty topty Nothing)
 searchNames fc rigc defaults trying depth defining topty env ambig (n :: ns) target
     = do defs <- get Ctxt
          visnsm <- traverse (visible (gamma defs) (currentNS defs :: nestedNS defs)) (n :: ns)
@@ -483,14 +484,14 @@ concreteDets {vars} fc defaults env top pos dets (arg :: args)
                                      concrete defs argnf False) (map snd args)
     concrete defs (NApp _ (NMeta n i _) _) True
         = do Just (Hole _ b) <- lookupDefExact n (gamma defs)
-                  | _ => throw (DeterminingArg fc n i ScopeEmpty top)
+                  | _ => throw (DeterminingArg fc n i Env.empty top)
              unless (implbind b) $
-                  throw (DeterminingArg fc n i ScopeEmpty top)
+                  throw (DeterminingArg fc n i Env.empty top)
     concrete defs (NApp _ (NMeta n i _) _) False
         = do Just (Hole _ b) <- lookupDefExact n (gamma defs)
-                  | def => throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                  | def => throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
              unless (implbind b) $
-                  throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                  throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
     concrete defs tm atTop = pure ()
 
 checkConcreteDets : {vars : _} ->
@@ -558,7 +559,7 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
                                 else tryUnifyUnambig
                                        (searchLocalVars fc rigc defaults trying' depth def top env nty)
                                        (tryGroups Nothing nty (hintGroups sd))
-                     else throw (CantSolveGoal fc (gamma defs) ScopeEmpty top Nothing)
+                     else throw (CantSolveGoal fc (gamma defs) Env.empty top Nothing)
               _ => do logNF "auto" 10 "Next target: " env nty
                       searchLocalVars fc rigc defaults trying' depth def top env nty
   where
@@ -567,7 +568,7 @@ searchType {vars} fc rigc defaults trying depth def checkdets top env target
     tryGroups : Maybe Error ->
                 NF vars -> List (Bool, List Name) -> Core (Term vars)
     tryGroups (Just err) nty [] = throw err
-    tryGroups Nothing nty [] = throw (CantSolveGoal fc (gamma !(get Ctxt)) ScopeEmpty top Nothing)
+    tryGroups Nothing nty [] = throw (CantSolveGoal fc (gamma !(get Ctxt)) Env.empty top Nothing)
     tryGroups merr nty ((ambigok, g) :: gs)
         = tryUnifyUnambig'
              (do logC "auto" 5

--- a/src/Core/AutoSearch.idr
+++ b/src/Core/AutoSearch.idr
@@ -215,10 +215,10 @@ getUsableEnv {vars = v :: vs} {done} fc rigc p (b :: env)
          if (multiplicity b == top || isErased rigc)
             then let 0 var = mkIsVar (hasLength p) in
                      (Local (binderLoc b) Nothing _ var,
-                       rewrite appendAssociative done (ScopeSingle v) vs in
+                       rewrite appendAssociative done (Scope.single v) vs in
                           weakenNs (sucR p) (binderType b)) ::
-                               rewrite appendAssociative done (ScopeSingle v) vs in rest
-            else rewrite appendAssociative done (ScopeSingle v) vs in rest
+                               rewrite appendAssociative done (Scope.single v) vs in rest
+            else rewrite appendAssociative done (Scope.single v) vs in rest
 
 -- A local is usable if it contains no holes in a determining argument position
 usableLocal : {vars : _} ->

--- a/src/Core/Case/CaseTree.idr
+++ b/src/Core/Case/CaseTree.idr
@@ -42,10 +42,11 @@ mutual
   data CaseAlt : Scoped where
        ||| Constructor for a data type; bind the arguments and subterms.
        ConCase : Name -> (tag : Int) -> (args : List Name) ->
-                 CaseTree (args ++ vars) -> CaseAlt vars
+                 CaseTree (AddInner vars args) -> CaseAlt vars
        ||| Lazy match for the Delay type use for codata types
        DelayCase : (ty : Name) -> (arg : Name) ->
-                   CaseTree (ty :: arg :: vars) -> CaseAlt vars
+                   CaseTree (AddInner vars [ty, arg]) -> CaseAlt vars
+                   -- TODO `arg` and `ty` should be swapped, as in Yaffle
        ||| Match against a literal
        ConstCase : Constant -> CaseTree vars -> CaseAlt vars
        ||| Catch-all case
@@ -100,8 +101,8 @@ public export
 data Pat : Type where
      PAs : FC -> Name -> Pat -> Pat
      PCon : FC -> Name -> (tag : Int) -> (arity : Nat) ->
-            Scopeable Pat -> Pat
-     PTyCon : FC -> Name -> (arity : Nat) -> Scopeable Pat -> Pat
+            List Pat -> Pat
+     PTyCon : FC -> Name -> (arity : Nat) -> List Pat -> Pat
      PConst : FC -> (c : Constant) -> Pat
      PArrow : FC -> (x : Name) -> Pat -> Pat -> Pat
      PDelay : FC -> LazyReason -> Pat -> Pat -> Pat
@@ -186,9 +187,9 @@ export
 Pretty IdrisSyntax Pat where
   prettyPrec d (PAs _ n p) = pretty0 n <++> keyword "@" <+> parens (pretty p)
   prettyPrec d (PCon _ n _ _ args) =
-    parenthesise (d > Open) $ hsep (pretty0 n :: map (prettyPrec App) (toList args))
+    parenthesise (d > Open) $ hsep (pretty0 n :: map (prettyPrec App) args)
   prettyPrec d (PTyCon _ n _ args) =
-    parenthesise (d > Open) $ hsep (pretty0 n :: map (prettyPrec App) (toList args))
+    parenthesise (d > Open) $ hsep (pretty0 n :: map (prettyPrec App) args)
   prettyPrec d (PConst _ c) = pretty c
   prettyPrec d (PArrow _ _ p q) =
     parenthesise (d > Open) $ pretty p <++> arrow <++> pretty q

--- a/src/Core/Case/CaseTree.idr
+++ b/src/Core/Case/CaseTree.idr
@@ -42,15 +42,18 @@ mutual
   data CaseAlt : Scoped where
        ||| Constructor for a data type; bind the arguments and subterms.
        ConCase : Name -> (tag : Int) -> (args : List Name) ->
-                 CaseTree (AddInner vars args) -> CaseAlt vars
+                 CaseTree (Scope.addInner vars args) -> CaseAlt vars
        ||| Lazy match for the Delay type use for codata types
        DelayCase : (ty : Name) -> (arg : Name) ->
-                   CaseTree (AddInner vars [ty, arg]) -> CaseAlt vars
+                   CaseTree (Scope.addInner vars [ty, arg]) -> CaseAlt vars
                    -- TODO `arg` and `ty` should be swapped, as in Yaffle
        ||| Match against a literal
        ConstCase : Constant -> CaseTree vars -> CaseAlt vars
        ||| Catch-all case
        DefaultCase : CaseTree vars -> CaseAlt vars
+
+export
+FreelyEmbeddable CaseTree where
 
 mutual
   public export

--- a/src/Core/CompileExpr.idr
+++ b/src/Core/CompileExpr.idr
@@ -366,7 +366,7 @@ export
 forgetDef : CDef -> NamedDef
 forgetDef (MkFun args def)
     = let ns = addLocs args []
-          args' = conArgs {vars = ScopeEmpty} args ns in
+          args' = conArgs {vars = Scope.empty} args ns in
           MkNmFun args' (forget def)
 forgetDef (MkCon t a nt) = MkNmCon t a nt
 forgetDef (MkForeign ccs fargs ty) = MkNmForeign ccs fargs ty

--- a/src/Core/Context.idr
+++ b/src/Core/Context.idr
@@ -557,11 +557,11 @@ mutual
 
 export
 HasNames (Env Term vars) where
-  full gam [] = pure ScopeEmpty
+  full gam [] = pure Env.empty
   full gam (b :: bs)
       = pure $ !(traverse (full gam) b) :: !(full gam bs)
 
-  resolved gam [] = pure ScopeEmpty
+  resolved gam [] = pure Env.empty
   resolved gam (b :: bs)
       = pure $ !(traverse (resolved gam) b) :: !(resolved gam bs)
 
@@ -1354,7 +1354,7 @@ addBuiltin n ty tot op
          , specArgs = []
          , inferrable = []
          , multiplicity = top
-         , localVars = ScopeEmpty
+         , localVars = Scope.empty
          , visibility = specified Public
          , totality = tot
          , isEscapeHatch = False

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -74,7 +74,7 @@ data Def : Type where
             (args : Scope) ->
             (treeCT : CaseTree args) ->
             (treeRT : CaseTree args) ->
-            (pats : List (vs ** (Env Term vs, Term vs, Term vs))) ->
+            (pats : List (vs : Scope ** (Env Term vs, Term vs, Term vs))) ->
                 -- original checked patterns (LHS/RHS) with the names in
                 -- the environment. Used for display purposes, for helping
                 -- find size changes in termination checking, and for

--- a/src/Core/Context/Context.idr
+++ b/src/Core/Context/Context.idr
@@ -101,7 +101,7 @@ data Def : Type where
            (parampos : List Nat) -> -- parameters
            (detpos : List Nat) -> -- determining arguments
            (flags : TypeFlags) -> -- should 'auto' implicits check
-           (mutwith : List Name) ->
+           (mutwith : List Name) -> -- TODO morally `Set Name`
            (datacons : Maybe (List Name)) ->
            (detagabbleBy : Maybe (List Nat)) ->
                     -- argument positions which can be used for

--- a/src/Core/Core.idr
+++ b/src/Core/Core.idr
@@ -814,27 +814,30 @@ export
 traversePair : (a -> Core b) -> (w, a) -> Core (w, b)
 traversePair f (w, a) = (w,) <$> f a
 
-export
-traverse_ : (a -> Core b) -> List a -> Core ()
-traverse_ f [] = pure ()
-traverse_ f (x :: xs)
-    = Core.do ignore (f x)
-              traverse_ f xs
-%inline
-export
-for_ : List a -> (a -> Core ()) -> Core ()
-for_ = flip traverse_
+namespace List
+  export
+  traverse_ : (a -> Core b) -> List a -> Core ()
+  traverse_ f [] = pure ()
+  traverse_ f (x :: xs)
+      = Core.do ignore (f x)
+                traverse_ f xs
 
-%inline
-export
-sequence : List (Core a) -> Core (List a)
-sequence (x :: xs)
-   = do
-        x' <- x
-        xs' <- sequence xs
-        pure (x' :: xs')
-sequence [] = pure []
+  %inline
+  export
+  for_ : List a -> (a -> Core ()) -> Core ()
+  for_ = flip traverse_
 
+  %inline
+  export
+  sequence : List (Core a) -> Core (List a)
+  sequence (x :: xs)
+     = do
+          x' <- x
+          xs' <- sequence xs
+          pure (x' :: xs')
+  sequence [] = pure []
+
+-- TODO put in namespace `List1`
 export
 traverseList1_ : (a -> Core b) -> List1 a -> Core ()
 traverseList1_ f xxs

--- a/src/Core/Env.idr
+++ b/src/Core/Env.idr
@@ -174,6 +174,12 @@ abstractFullEnvType fc (b :: env) tm
       in abstractFullEnvType fc env (Bind fc _ bnd tm)
 
 export
+mkExplicit : Env Term vs -> Env Term vs
+mkExplicit [] = Env.empty
+mkExplicit (Pi fc c _ ty :: env) = Pi fc c Explicit ty :: mkExplicit env
+mkExplicit (b :: env) = b :: mkExplicit env
+
+export
 letToLam : Env Term vars -> Env Term vars
 letToLam [] = []
 letToLam (Let fc c val ty :: env) = Lam fc c Explicit ty :: letToLam env

--- a/src/Core/Env.idr
+++ b/src/Core/Env.idr
@@ -17,14 +17,14 @@ import Libraries.Data.SnocList.HasLength
 -- Environment containing types and values of local variables
 public export
 data Env : (tm : Scoped) -> Scope -> Type where
-     Nil : Env tm ScopeEmpty
+     Nil : Env tm Scope.empty
      (::) : Binder (tm vars) -> Env tm vars -> Env tm (x :: vars)
 
 %name Env rho
 
 public export
-ScopeEmpty : {tm: _} -> Env tm []
-ScopeEmpty = []
+empty : Env tm []
+empty = []
 
 export
 extend : (x : Name) -> Binder (tm vars) -> Env tm vars -> Env tm (x :: vars)
@@ -53,10 +53,26 @@ lengthExplicitPi (Pi _ _ Explicit _ :: rho) = S (lengthExplicitPi rho)
 lengthExplicitPi (_ :: rho) = lengthExplicitPi rho
 
 export
-namesNoLet : {xs : _} -> Env tm xs -> Scopeable Name
+namesNoLet : {xs : _} -> Env tm xs -> List Name
 namesNoLet [] = []
 namesNoLet (Let _ _ _ _ :: xs) = namesNoLet xs
 namesNoLet {xs = x :: _} (_ :: env) = x :: namesNoLet env
+
+export
+eraseLinear : Env tm vs -> Env tm vs
+eraseLinear [] = Env.empty
+eraseLinear (b :: bs)
+    = if isLinear (multiplicity b)
+         then setMultiplicity b erased :: eraseLinear bs
+         else b :: eraseLinear bs
+
+export
+getErased : {vs : _} -> Env tm vs -> List (Var vs)
+getErased [] = []
+getErased (b :: bs)
+    = if isErased (multiplicity b)
+         then MkVar First :: map weaken (getErased bs)
+         else map weaken (getErased bs)
 
 public export
 data IsDefined : Name -> Scope -> Type where
@@ -111,7 +127,7 @@ export
 getBinder : Weaken tm =>
             {vars : _} -> {idx : Nat} ->
             (0 p : IsVar x idx vars) -> Env tm vars -> Binder (tm vars)
-getBinder el env = getBinderUnder ScopeEmpty el env
+getBinder el env = getBinderUnder Scope.empty el env
 
 -- For getBinderLoc, we are not reusing getBinder because there is no need to
 -- needlessly weaken stuff;
@@ -164,9 +180,11 @@ letToLam (Let fc c val ty :: env) = Lam fc c Explicit ty :: letToLam env
 letToLam (b :: env) = b :: letToLam env
 
 mutual
+  -- TODO turn list into set of nats throughout
+
   -- Quicker, if less safe, to store variables as a Nat, for quick comparison
   findUsed : {vars : _} ->
-             Env Term vars -> Scopeable Nat -> Term vars -> Scopeable Nat
+             Env Term vars -> List Nat -> Term vars -> List Nat
   findUsed env used (Local fc r idx p)
       = if elemBy eqNat idx used
            then used
@@ -178,7 +196,7 @@ mutual
   findUsed env used (Meta _ _ _ args)
       = findUsedArgs env used args
     where
-      findUsedArgs : Env Term vars -> Scopeable Nat -> List (Term vars) -> Scopeable Nat
+      findUsedArgs : Env Term vars -> List Nat -> List (Term vars) -> List Nat
       findUsedArgs env u [] = u
       findUsedArgs env u (a :: as)
           = findUsedArgs env (findUsed env u a) as
@@ -188,7 +206,7 @@ mutual
                           (map S (findUsedInBinder env used b))
                           tm)
     where
-      dropS : Scopeable Nat -> Scopeable Nat
+      dropS : List Nat -> List Nat
       dropS [] = []
       dropS (Z :: xs) = dropS xs
       dropS (S p :: xs) = p :: dropS xs
@@ -205,8 +223,8 @@ mutual
   findUsed env used _ = used
 
   findUsedInBinder : {vars : _} ->
-                     Env Term vars -> Scopeable Nat ->
-                     Binder (Term vars) -> Scopeable Nat
+                     Env Term vars -> List Nat ->
+                     Binder (Term vars) -> List Nat
   findUsedInBinder env used (Let _ _ val ty)
     = findUsed env (findUsed env used val) ty
   findUsedInBinder env used (PLet _ _ val ty)
@@ -222,16 +240,16 @@ toVar _ _ = Nothing
 
 export
 findUsedLocs : {vars : _} ->
-               Env Term vars -> Term vars -> Scopeable (Var vars)
+               Env Term vars -> Term vars -> List (Var vars)
 findUsedLocs env tm
-    = mapMaybe (toVar _) (findUsed env ScopeEmpty tm)
+    = mapMaybe (toVar _) (findUsed env [] tm)
 
-isUsed : Nat -> Scopeable (Var vars) -> Bool
+isUsed : Nat -> List (Var vars) -> Bool
 isUsed n [] = False
 isUsed n (v :: vs) = n == varIdx v || isUsed n vs
 
 mkShrinkSub : {n : _} ->
-              (vars : _) -> Scopeable (Var (n :: vars)) ->
+              (vars : _) -> List (Var (n :: vars)) ->
               (newvars ** Thin newvars (n :: vars))
 mkShrinkSub [] els
     = if isUsed 0 els
@@ -244,7 +262,7 @@ mkShrinkSub (x :: xs) els
         else (_ ** Drop subRest)
 
 mkShrink : {vars : _} ->
-           Scopeable (Var vars) ->
+           List (Var vars) ->
            (newvars ** Thin newvars vars)
 mkShrink {vars = []} xs = (_ ** Refl)
 mkShrink {vars = v :: vs} xs = mkShrinkSub _ xs
@@ -283,11 +301,13 @@ mkEnv fc (n :: ns) = PVar fc top Explicit (Erased fc Placeholder) :: mkEnv fc ns
 
 -- Update an environment so that all names are guaranteed unique. In the
 -- case of a clash, the most recently bound is left unchanged.
+--
+-- TODO replace list of `used` names with a proper set
 export
 uniqifyEnv : {vars : _} ->
              Env Term vars ->
              (vars' ** (Env Term vars', CompatibleVars vars vars'))
-uniqifyEnv env = uenv ScopeEmpty env
+uniqifyEnv env = uenv [] env
   where
     next : Name -> Name
     next (MN n i) = MN n (i + 1)
@@ -295,7 +315,7 @@ uniqifyEnv env = uenv ScopeEmpty env
     next (NS ns n) = NS ns (next n)
     next n = MN (show n) 0
 
-    uniqueLocal : Scope -> Name -> Name
+    uniqueLocal : List Name -> Name -> Name
     uniqueLocal vs n
        = if n `elem` vs
                  -- we'll find a new name eventualy since the list of names
@@ -307,7 +327,7 @@ uniqifyEnv env = uenv ScopeEmpty env
             else n
 
     uenv : {vars : _} ->
-           Scope -> Env Term vars ->
+           List Name -> Env Term vars ->
            (vars' ** (Env Term vars', CompatibleVars vars vars'))
     uenv used [] = ([] ** ([], Pre))
     uenv used {vars = v :: vs} (b :: bs)
@@ -338,8 +358,8 @@ close fc nm env tm
     substs s env (rewrite appendNilRightNeutral vars in tm)
 
   where
-    mkSubstEnv : Int -> Env Term vs -> (SizeOf vs, SubstEnv vs ScopeEmpty)
-    mkSubstEnv i [] = (zero, ScopeEmpty)
+    mkSubstEnv : Int -> Env Term vs -> (SizeOf vs, SubstEnv vs Scope.empty)
+    mkSubstEnv i [] = (zero, Subst.empty)
     mkSubstEnv i (v :: vs)
        = let (s, env) = mkSubstEnv (i + 1) vs in
          (suc s, Ref fc Bound (MN nm i) :: env)

--- a/src/Core/Metadata.idr
+++ b/src/Core/Metadata.idr
@@ -357,7 +357,7 @@ normaliseTypes
     nfType : Defs -> (NonEmptyFC, (Name, Nat, ClosedTerm)) ->
              Core (NonEmptyFC, (Name, Nat, ClosedTerm))
     nfType defs (loc, (n, len, ty))
-       = pure (loc, (n, len, !(normaliseArgHoles defs ScopeEmpty ty)))
+       = pure (loc, (n, len, !(normaliseArgHoles defs Env.empty ty)))
 
 record TTMFile where
   constructor MkTTMFile

--- a/src/Core/Name/Scoped.idr
+++ b/src/Core/Name/Scoped.idr
@@ -29,9 +29,10 @@ public export
 Scope : Type
 Scope = Scopeable Name
 
-public export
-ScopeEmpty : Scopeable a
-ScopeEmpty = []
+namespace Scope
+  public export
+  empty : Scopeable a
+  empty = []
 
 {-
 public export

--- a/src/Core/Name/Scoped.idr
+++ b/src/Core/Name/Scoped.idr
@@ -30,8 +30,25 @@ Scope : Type
 Scope = Scopeable Name
 
 public export
-ScopeEmpty : {a: Type} -> Scopeable a
+ScopeEmpty : Scopeable a
 ScopeEmpty = []
+
+{-
+public export
+ScopeExt : Scopeable a -> List a -> Scopeable a
+ScopeExt vars ns = ns ++ vars
+--- TODO replace by `vars <>< ns`
+-}
+
+public export
+AddInner : Scopeable a -> Scopeable a -> Scopeable a
+AddInner vars inner = inner ++ vars
+--- TODO replace by `vars ++ inner`
+
+public export
+ScopeBind : Scopeable a -> a -> Scopeable a
+ScopeBind vars n = n :: vars
+--- TODO replace with `<:`
 
 public export
 ScopeSingle : a -> Scopeable a

--- a/src/Core/Name/Scoped.idr
+++ b/src/Core/Name/Scoped.idr
@@ -34,26 +34,26 @@ namespace Scope
   empty : Scopeable a
   empty = []
 
-{-
-public export
-ScopeExt : Scopeable a -> List a -> Scopeable a
-ScopeExt vars ns = ns ++ vars
---- TODO replace by `vars <>< ns`
--}
+  {-
+  public export
+  ext : Scopeable a -> List a -> Scopeable a
+  ext vars ns = ns ++ vars
+  --- TODO replace by `vars <>< ns`
+  -}
 
-public export
-AddInner : Scopeable a -> Scopeable a -> Scopeable a
-AddInner vars inner = inner ++ vars
---- TODO replace by `vars ++ inner`
+  public export
+  addInner : Scopeable a -> Scopeable a -> Scopeable a
+  addInner vars inner = inner ++ vars
+  --- TODO replace by `vars ++ inner`
 
-public export
-ScopeBind : Scopeable a -> a -> Scopeable a
-ScopeBind vars n = n :: vars
---- TODO replace with `<:`
+  public export
+  bind : Scopeable a -> a -> Scopeable a
+  bind vars n = n :: vars
+  --- TODO replace with `<:`
 
-public export
-ScopeSingle : a -> Scopeable a
-ScopeSingle n = [n]
+  public export
+  single : a -> Scopeable a
+  single n = [n]
 
 ||| A scoped definition is one indexed by a scope
 public export

--- a/src/Core/Normalise.idr
+++ b/src/Core/Normalise.idr
@@ -268,23 +268,23 @@ replace' {vars} tmpi defs env lhs parg tm
              pure (Bind fc x b' (refsToLocals (Add x x' None) sc'))
     repSub (NApp fc hd [])
         = do empty <- clearDefs defs
-             quote empty env (NApp fc hd ScopeEmpty)
+             quote empty env (NApp fc hd [])
     repSub (NApp fc hd args)
         = do args' <- traverse (traversePair repArg) args
              pure $ applyStackWithFC
-                        !(replace' tmpi defs env lhs parg (NApp fc hd ScopeEmpty))
+                        !(replace' tmpi defs env lhs parg (NApp fc hd []))
                         args'
     repSub (NDCon fc n t a args)
         = do args' <- traverse (traversePair repArg) args
              empty <- clearDefs defs
              pure $ applyStackWithFC
-                        !(quote empty env (NDCon fc n t a ScopeEmpty))
+                        !(quote empty env (NDCon fc n t a []))
                         args'
     repSub (NTCon fc n t a args)
         = do args' <- traverse (traversePair repArg) args
              empty <- clearDefs defs
              pure $ applyStackWithFC
-                        !(quote empty env (NTCon fc n t a ScopeEmpty))
+                        !(quote empty env (NTCon fc n t a []))
                         args'
     repSub (NAs fc s a p)
         = do a' <- repSub a

--- a/src/Core/Normalise/Convert.idr
+++ b/src/Core/Normalise/Convert.idr
@@ -91,7 +91,7 @@ mutual
   allConvNF : {auto c : Ref Ctxt Defs} ->
               {vars : _} ->
               Ref QVar Int -> Bool -> Defs -> Env Term vars ->
-              Scopeable (NF vars) -> Scopeable (NF vars) -> Core Bool
+              List (NF vars) -> List (NF vars) -> Core Bool
   allConvNF q i defs env [] [] = pure True
   allConvNF q i defs env (x :: xs) (y :: ys)
       = do ok <- allConvNF q i defs env xs ys
@@ -102,7 +102,7 @@ mutual
   -- return False if anything differs at the head, to quickly find
   -- conversion failures without going deeply into all the arguments.
   -- True means they might still match
-  quickConv : Scopeable (NF vars) -> Scopeable (NF vars) -> Bool
+  quickConv : List (NF vars) -> List (NF vars) -> Bool
   quickConv [] [] = True
   quickConv (x :: xs) (y :: ys) = quickConvArg x y && quickConv xs ys
     where
@@ -132,7 +132,7 @@ mutual
   allConv : {auto c : Ref Ctxt Defs} ->
             {vars : _} ->
             Ref QVar Int -> Bool -> Defs -> Env Term vars ->
-            Scopeable (Closure vars) -> Scopeable (Closure vars) -> Core Bool
+            List (Closure vars) -> List (Closure vars) -> Core Bool
   allConv q i defs env xs ys
       = do xsnf <- traverse (evalClosure defs) xs
            ysnf <- traverse (evalClosure defs) ys
@@ -228,7 +228,7 @@ mutual
                 {vars : _} ->
                 Ref QVar Int -> Bool -> Defs -> Env Term vars ->
                 Name -> Name ->
-                Scopeable (Closure vars) -> Scopeable (Closure vars) -> Core Bool
+                List (Closure vars) -> List (Closure vars) -> Core Bool
   chkSameDefs q i defs env n n' nargs nargs'
      = do Just (PMDef _ args ct rt _) <- lookupDefExact n (gamma defs)
                | _ => pure False
@@ -244,7 +244,7 @@ mutual
      where
        -- We've only got the index into the argument list, and the indices
        -- don't match up, which is annoying. But it'll always be there!
-       getArgPos : Nat -> Scopeable (Closure vars) -> Maybe (Closure vars)
+       getArgPos : Nat -> List (Closure vars) -> Maybe (Closure vars)
        getArgPos _ [] = Nothing
        getArgPos Z (c :: cs) = pure c
        getArgPos (S k) (c :: cs) = getArgPos k cs
@@ -266,8 +266,8 @@ mutual
   chkConvCaseBlock : {auto c : Ref Ctxt Defs} ->
                      {vars : _} ->
                      FC -> Ref QVar Int -> Bool -> Defs -> Env Term vars ->
-                     NHead vars -> Scopeable (Closure vars) ->
-                     NHead vars -> Scopeable (Closure vars) -> Core Bool
+                     NHead vars -> List (Closure vars) ->
+                     NHead vars -> List (Closure vars) -> Core Bool
   chkConvCaseBlock fc q i defs env (NRef _ n) nargs (NRef _ n') nargs'
       = do NS _ (CaseBlock _ _) <- full (gamma defs) n
               | _ => pure False
@@ -306,7 +306,7 @@ mutual
       findArgPos (Case idx p _ _) = Just idx
       findArgPos _ = Nothing
 
-      getScrutinee : Nat -> Scopeable (Closure vs) -> Maybe (Closure vs)
+      getScrutinee : Nat -> List (Closure vs) -> Maybe (Closure vs)
       getScrutinee Z (x :: xs) = Just x
       getScrutinee (S k) (x :: xs) = getScrutinee k xs
       getScrutinee _ _ = Nothing
@@ -346,7 +346,7 @@ mutual
   Convert NF where
     convGen q i defs env (NBind fc x b sc) (NBind _ x' b' sc')
         = do var <- genName "conv"
-             let c = MkClosure defaultOpts ScopeEmpty env (Ref fc Bound var)
+             let c = MkClosure defaultOpts LocalEnv.empty env (Ref fc Bound var)
              bok <- convBinders q i defs env b b'
              if bok
                 then do bsc <- sc defs c
@@ -372,7 +372,7 @@ mutual
     convGen q inf defs env (NApp fc val args) (NApp _ val' args')
         = if !(chkConvHead q inf defs env val val')
              then do i <- getInfPos val
-                     allConv q inf defs env (dropInf 0 i $ toList args1) (dropInf 0 i $ toList args2)
+                     allConv q inf defs env (dropInf 0 i args1) (dropInf 0 i args2)
              else chkConvCaseBlock fc q inf defs env val args1 val' args2
         where
           getInfPos : NHead vars -> Core (List Nat)
@@ -384,7 +384,7 @@ mutual
                    else pure []
           getInfPos _ = pure []
 
-          dropInf : Nat -> List Nat -> Scopeable a -> Scopeable a
+          dropInf : Nat -> List Nat -> List a -> List a
           dropInf _ [] xs = xs
           dropInf _ _ [] = []
           dropInf i ds (x :: xs)
@@ -393,10 +393,10 @@ mutual
                    else x :: dropInf (S i) ds xs
 
           -- Discard file context information irrelevant for conversion checking
-          args1 : Scopeable (Closure vars)
+          args1 : List (Closure vars)
           args1 = map snd args
 
-          args2 : Scopeable (Closure vars)
+          args2 : List (Closure vars)
           args2 = map snd args'
 
     convGen q i defs env (NDCon _ nm tag _ args) (NDCon _ nm' tag' _ args')

--- a/src/Core/Normalise/Eval.idr
+++ b/src/Core/Normalise/Eval.idr
@@ -92,7 +92,7 @@ record TermWithEnv (free : Scope) where
     constructor MkTermEnv
     { varsEnv : Scope }
     locEnv : LocalEnv free varsEnv
-    term : Term $ AddInner free varsEnv
+    term : Term $ Scope.addInner free varsEnv
 
 parameters (defs : Defs) (topopts : EvalOpts)
   mutual
@@ -110,7 +110,7 @@ parameters (defs : Defs) (topopts : EvalOpts)
         -- Yes, it's just a map, but specialising it by hand since we
         -- use this a *lot* and it saves the run time overhead of making
         -- a closure and calling APPLY.
-        closeArgs : List (Term (AddInner free vars)) -> List (Closure free)
+        closeArgs : List (Term (Scope.addInner free vars)) -> List (Closure free)
         closeArgs [] = []
         closeArgs (t :: ts) = MkClosure topopts locs env t :: closeArgs ts
     eval env locs (Bind fc x (Lam _ r _ ty) scope) (thunk :: stk)
@@ -322,7 +322,7 @@ parameters (defs : Defs) (topopts : EvalOpts)
     getCaseBound : List (Closure free) ->
                    (args : Scope) ->
                    LocalEnv free more ->
-                   Maybe (LocalEnv free (AddInner more args))
+                   Maybe (LocalEnv free (Scope.addInner more args))
     getCaseBound []            []        loc = Just loc
     getCaseBound []            (_ :: _)  loc = Nothing -- mismatched arg length
     getCaseBound (arg :: args) []        loc = Nothing -- mismatched arg length
@@ -336,7 +336,7 @@ parameters (defs : Defs) (topopts : EvalOpts)
                  Stack free ->
                  (args : List Name) ->
                  List (Closure free) ->
-                 CaseTree (AddInner more args) ->
+                 CaseTree (Scope.addInner more args) ->
                  Core (CaseResult (TermWithEnv free))
     evalConAlt env loc opts fc stk args args' sc
          = do let Just bound = getCaseBound args' args loc

--- a/src/Core/Normalise/Quote.idr
+++ b/src/Core/Normalise/Quote.idr
@@ -81,15 +81,15 @@ mutual
   quoteArgs : {auto c : Ref Ctxt Defs} ->
               {bound, free : _} ->
               Ref QVar Int -> QuoteOpts -> Defs -> Bounds bound ->
-              Env Term free -> Scopeable (Closure free) ->
-              Core (Scopeable (Term (bound ++ free)))
+              Env Term free -> List (Closure free) ->
+              Core (List (Term (bound ++ free)))
   quoteArgs q opts defs bounds env = traverse (quoteArg q opts defs bounds env)
 
   quoteArgsWithFC : {auto c : Ref Ctxt Defs} ->
                     {bound, free : _} ->
                     Ref QVar Int -> QuoteOpts -> Defs -> Bounds bound ->
-                    Env Term free -> Scopeable (FC, Closure free) ->
-                    Core (Scopeable (FC, Term (bound ++ free)))
+                    Env Term free -> List (FC, Closure free) ->
+                    Core (List (FC, Term (bound ++ free)))
   quoteArgsWithFC q opts defs bounds env
       = traverse (quoteArgWithFC q opts defs bounds env)
 
@@ -128,7 +128,7 @@ mutual
   quoteHead q opts defs fc bounds env (NRef nt n) = pure $ Ref fc nt n
   quoteHead q opts defs fc bounds env (NMeta n i args)
       = do args' <- quoteArgs q opts defs bounds env args
-           pure $ Meta fc n i (toList args')
+           pure $ Meta fc n i args'
 
   quotePi : {auto c : Ref Ctxt Defs} ->
             {bound, free : _} ->

--- a/src/Core/SchemeEval/Compile.idr
+++ b/src/Core/SchemeEval/Compile.idr
@@ -20,6 +20,7 @@ import Core.SchemeEval.ToScheme
 import Core.TT
 
 import Data.List
+import Data.List.Quantifiers
 import Data.SnocList
 
 import Libraries.Utils.Scheme
@@ -79,13 +80,13 @@ getName (Bound x) = x
 getName (Free x) = x
 
 public export
-data SchVars : Scoped where
-     Nil : SchVars []
-     (::) : SVar -> SchVars ns -> SchVars (n :: ns)
+SchVars : Scoped
+SchVars = All (\_ => SVar)
 
 Show (SchVars ns) where
   show xs = show (toList xs)
     where
+      -- TODO move to Data.List.Quantifiers
       toList : forall ns . SchVars ns -> List String
       toList [] = []
       toList (Bound x :: xs) = x :: toList xs
@@ -521,7 +522,7 @@ compileBody _ n (DCon tag arity newtypeArg)
          let body
                = Vector (cast tag)
                         (toScheme n :: toScheme emptyFC ::
-                             map (Var . schVarName) (toList args))
+                             map (Var . schVarName) args)
          pure (bindArgs n argvs [] body)
   where
     mkArgNs : Int -> Nat -> List Name
@@ -538,7 +539,7 @@ compileBody _ n (TCon tag arity parampos detpos flags mutwith datacons detagabbl
                         (IntegerVal (cast tag) ::
                          StringVal (show n) ::
                           toScheme n :: toScheme emptyFC ::
-                            map (Var . schVarName) (toList args))
+                            map (Var . schVarName) args)
          pure (bindArgs n argvs [] body)
   where
     mkArgNs : Int -> Nat -> List Name

--- a/src/Core/SchemeEval/Evaluate.idr
+++ b/src/Core/SchemeEval/Evaluate.idr
@@ -8,6 +8,8 @@ import Core.SchemeEval.Compile
 import Core.SchemeEval.ToScheme
 import Core.TT
 
+import Data.List.Quantifiers
+
 import Libraries.Data.NameMap
 import Libraries.Utils.Scheme
 

--- a/src/Core/SchemeEval/Evaluate.idr
+++ b/src/Core/SchemeEval/Evaluate.idr
@@ -12,7 +12,7 @@ import Libraries.Data.NameMap
 import Libraries.Utils.Scheme
 
 public export
-data SObj : Scope -> Type where
+data SObj : Scoped where
      MkSObj : ForeignObj -> SchVars vars -> SObj vars
 
 -- Values, which we read off evaluated scheme objects.
@@ -22,13 +22,13 @@ data SObj : Scope -> Type where
 -- recording a LocalEnv for example).
 mutual
   public export
-  data SHead : Scope -> Type where
+  data SHead : Scoped where
        SLocal : (idx : Nat) -> (0 p : IsVar nm idx vars) -> SHead vars
        SRef : NameType -> Name -> SHead vars
        SMeta : Name -> Int -> List (Core (SNF vars)) -> SHead vars
 
   public export
-  data SNF : Scope -> Type where
+  data SNF : Scoped where
        SBind    : FC -> (x : Name) -> Binder (SNF vars) ->
                   (SObj vars -> Core (SNF vars)) -> SNF vars
        SApp     : FC -> SHead vars -> List (Core (SNF vars)) -> SNF vars
@@ -386,7 +386,7 @@ quoteObj : {auto c : Ref Ctxt Defs} ->
            SObj vars -> Core (Term vars)
 quoteObj (MkSObj val schEnv)
     = do i <- newRef Sym 0
-         quote' {outer = ScopeEmpty} schEnv val
+         quote' {outer = Scope.empty} schEnv val
 
 mutual
   snfVector : Ref Ctxt Defs =>

--- a/src/Core/TT.idr
+++ b/src/Core/TT.idr
@@ -385,8 +385,9 @@ notCovering = MkTotality Unchecked (MissingCases [])
 namespace Bounds
   public export
   data Bounds : Scoped where
-       None : Bounds ScopeEmpty
+       None : Bounds Scope.empty
        Add : (x : Name) -> Name -> Bounds xs -> Bounds (x :: xs)
+       -- TODO add diagonal constructor
 
   export
   sizeOf : Bounds xs -> SizeOf xs

--- a/src/Core/TT/Subst.idr
+++ b/src/Core/TT/Subst.idr
@@ -12,13 +12,14 @@ import Libraries.Data.SnocList.SizeOf
 
 %default total
 
+-- TODO replace by pointwise lifting: `Subst tm ds vars = All (\_. tm vars) ds`
 public export
 data Subst : Scoped -> Scope -> Scoped where
   Nil : Subst tm ScopeEmpty vars
   (::) : tm vars -> Subst tm ds vars -> Subst tm (d :: ds) vars
 
 public export
-ScopeEmpty : {tm: _} -> Subst tm ScopeEmpty vars
+ScopeEmpty : Subst tm ScopeEmpty vars
 ScopeEmpty = []
 
 
@@ -30,6 +31,7 @@ namespace Var
   index (t :: _) (MkVar First) = t
   index (_ :: ts) (MkVar (Later p)) = index ts (MkVar p)
 
+-- TODO revisit order of `dropped` and `Subst`
 export
 findDrop :
   (Var vars -> tm vars) ->
@@ -52,6 +54,7 @@ find k outer dropped var sub = case locateVar outer var of
   Left var => k (embed var)
   Right var => weakenNs outer (findDrop k dropped var sub)
 
+-- TODO rename `outer`
 public export
 0 Substitutable : Scoped -> Scoped -> Type
 Substitutable val tm

--- a/src/Core/TT/Subst.idr
+++ b/src/Core/TT/Subst.idr
@@ -15,12 +15,12 @@ import Libraries.Data.SnocList.SizeOf
 -- TODO replace by pointwise lifting: `Subst tm ds vars = All (\_. tm vars) ds`
 public export
 data Subst : Scoped -> Scope -> Scoped where
-  Nil : Subst tm ScopeEmpty vars
+  Nil : Subst tm Scope.empty vars
   (::) : tm vars -> Subst tm ds vars -> Subst tm (d :: ds) vars
 
 public export
-ScopeEmpty : Subst tm ScopeEmpty vars
-ScopeEmpty = []
+empty : Subst tm Scope.empty vars
+empty = []
 
 
 namespace Var

--- a/src/Core/TT/Term.idr
+++ b/src/Core/TT/Term.idr
@@ -106,7 +106,7 @@ data Term : Scoped where
      Meta : FC -> Name -> Int -> List (Term vars) -> Term vars
      Bind : FC -> (x : Name) ->
             (b : Binder (Term vars)) ->
-            (scope : Term (ScopeBind vars x)) -> Term vars
+            (scope : Term (Scope.bind vars x)) -> Term vars
      App : FC -> (fn : Term vars) -> (arg : Term vars) -> Term vars
      -- as patterns; since we check LHS patterns as terms before turning
      -- them into patterns, this helps us get it right. When normalising,

--- a/src/Core/TT/Term.idr
+++ b/src/Core/TT/Term.idr
@@ -106,7 +106,7 @@ data Term : Scoped where
      Meta : FC -> Name -> Int -> List (Term vars) -> Term vars
      Bind : FC -> (x : Name) ->
             (b : Binder (Term vars)) ->
-            (scope : Term (x :: vars)) -> Term vars
+            (scope : Term (ScopeBind vars x)) -> Term vars
      App : FC -> (fn : Term vars) -> (arg : Term vars) -> Term vars
      -- as patterns; since we check LHS patterns as terms before turning
      -- them into patterns, this helps us get it right. When normalising,

--- a/src/Core/TT/Term/Subst.idr
+++ b/src/Core/TT/Term/Subst.idr
@@ -60,5 +60,5 @@ substs : SizeOf dropped -> SubstEnv dropped vars -> Term (dropped ++ vars) -> Te
 substs dropped env tm = substTerm zero dropped env tm
 
 export
-subst : Term vars -> Term (x :: vars) -> Term vars
+subst : Term vars -> Term (ScopeBind vars x) -> Term vars
 subst val tm = substs (suc zero) (ScopeSingle val) tm

--- a/src/Core/TT/Term/Subst.idr
+++ b/src/Core/TT/Term/Subst.idr
@@ -20,9 +20,6 @@ public export
 SubstEnv : Scope -> Scoped
 SubstEnv = Subst Term
 
-ScopeSingle : Term vars -> SubstEnv [x] vars
-ScopeSingle n = [n]
-
 substTerm : Substitutable Term Term
 substTerms : Substitutable Term (List . Term)
 substBinder : Substitutable Term (Binder . Term)
@@ -61,4 +58,4 @@ substs dropped env tm = substTerm zero dropped env tm
 
 export
 subst : Term vars -> Term (ScopeBind vars x) -> Term vars
-subst val tm = substs (suc zero) (ScopeSingle val) tm
+subst val tm = substs (suc zero) [val] tm

--- a/src/Core/TT/Term/Subst.idr
+++ b/src/Core/TT/Term/Subst.idr
@@ -57,5 +57,5 @@ substs : SizeOf dropped -> SubstEnv dropped vars -> Term (dropped ++ vars) -> Te
 substs dropped env tm = substTerm zero dropped env tm
 
 export
-subst : Term vars -> Term (ScopeBind vars x) -> Term vars
+subst : Term vars -> Term (Scope.bind vars x) -> Term vars
 subst val tm = substs (suc zero) [val] tm

--- a/src/Core/TT/Traversals.idr
+++ b/src/Core/TT/Traversals.idr
@@ -10,6 +10,13 @@ import Libraries.Data.SortedSet
 
 %default covering
 
+-- TODO fix future type error
+export
+unBinds : Term vars -> Exists (\ outer => Term (outer <>> vars))
+unBinds (Bind _ x _ scope) = let (Evidence outer t) = unBinds scope in
+                             Evidence (outer :< x) t
+unBinds t = Evidence [<] t
+
 export
 onPRefs : Monoid m =>
           (Name      -> m) ->

--- a/src/Core/TT/Var.idr
+++ b/src/Core/TT/Var.idr
@@ -25,12 +25,14 @@ import Libraries.Data.Erased
 ------------------------------------------------------------------------
 -- IsVar Predicate
 
+-- TODO need a copy of `IsVar` for both
+
 ||| IsVar n k ns is a proof that
 ||| the name n
 ||| is a position k
 ||| in the snoclist ns
 public export
-data IsVar : a -> Nat -> Scopeable a -> Type where
+data IsVar : a -> Nat -> List a -> Type where
      First : IsVar n Z (n :: ns)
      Later : IsVar n i ns -> IsVar n (S i) (m :: ns)
 
@@ -45,7 +47,7 @@ finIdx (Later l) = FS (finIdx l)
 ||| Recover the value pointed at by an IsVar proof
 ||| O(n) in the size of the index
 export
-nameAt : {vars : Scopeable a} -> {idx : Nat} -> (0 p : IsVar n idx vars) -> a
+nameAt : {vars : List a} -> {idx : Nat} -> (0 p : IsVar n idx vars) -> a
 nameAt {vars = n :: _} First = n
 nameAt (Later p) = nameAt p
 
@@ -69,9 +71,9 @@ mkIsVarChiply hl
 ||| Compute the remaining scope once the target variable has been removed
 public export
 dropIsVar :
-  (ns : Scopeable a) ->
+  (ns : List a) ->
   {idx : Nat} -> (0 p : IsVar name idx ns) ->
-  Scopeable a
+  List a
 dropIsVar (_ :: xs) First = xs
 dropIsVar (n :: xs) (Later p) = n :: dropIsVar xs p
 
@@ -127,7 +129,7 @@ locateIsVar s p = case choose (idx < size s) of
 ||| and a proof that the name is at that position in the scope.
 ||| Everything but the De Bruijn index is erased.
 public export
-record Var {0 a : Type} (vars : Scopeable a) where
+record Var {0 a : Type} (vars : List a) where
   constructor MkVar
   {varIdx : Nat}
   {0 varNm : a}
@@ -168,13 +170,13 @@ Eq (Var xs) where
 
 ||| Removing var 0, strengthening all the other ones
 export
-dropFirst : Scopeable (Var (n :: vs)) -> Scopeable (Var vs)
+dropFirst : List (Var (ScopeBind vs n)) -> List (Var vs)
 dropFirst = List.mapMaybe isLater
 
 ||| Manufacturing a thinning from a list of variables to keep
 export
 thinFromVars :
-  (vars : _) -> Scopeable (Var vars) ->
+  (vars : _) -> List (Var vars) ->
   (newvars ** Thin newvars vars)
 thinFromVars [] els
     = (_ ** Refl)
@@ -192,7 +194,7 @@ Show (Var ns) where
 -- Named variable in scope
 
 public export
-record NVar {0 a : Type} (nm : a) (vars : Scopeable a) where
+record NVar {0 a : Type} (nm : a) (vars : List a) where
   constructor MkNVar
   {nvarIdx : Nat}
   0 nvarPrf : IsVar nm nvarIdx vars
@@ -231,20 +233,20 @@ locateNVar s (MkNVar p) = case locateIsVar s p of
   Right p => Right (MkNVar (runErased p))
 
 public export
-dropNVar : {ns : Scopeable a} -> NVar nm ns -> Scopeable a
+dropNVar : {ns : List a} -> NVar nm ns -> List a
 dropNVar (MkNVar p) = dropIsVar ns p
 
 ------------------------------------------------------------------------
 -- Scope checking
 
 export
-isDeBruijn : Nat -> (vars : Scope) -> Maybe (Var vars)
+isDeBruijn : Nat -> (vars : List Name) -> Maybe (Var vars)
 isDeBruijn Z (_ :: _) = pure (MkVar First)
 isDeBruijn (S k) (_ :: vs) = later <$> isDeBruijn k vs
 isDeBruijn _ _ = Nothing
 
 export
-isNVar : (n : Name) -> (ns : Scope) -> Maybe (NVar n ns)
+isNVar : (n : Name) -> (ns : List Name) -> Maybe (NVar n ns)
 isNVar n [] = Nothing
 isNVar n (m :: ms)
     = case nameEq n m of
@@ -252,7 +254,7 @@ isNVar n (m :: ms)
            Just Refl => pure (MkNVar First)
 
 export
-isVar : (n : Name) -> (ns : Scope) -> Maybe (Var ns)
+isVar : (n : Name) -> (ns : List Name) -> Maybe (Var ns)
 isVar n ns = forgetName <$> isNVar n ns
 
 export

--- a/src/Core/TT/Var.idr
+++ b/src/Core/TT/Var.idr
@@ -170,7 +170,7 @@ Eq (Var xs) where
 
 ||| Removing var 0, strengthening all the other ones
 export
-dropFirst : List (Var (ScopeBind vs n)) -> List (Var vs)
+dropFirst : List (Var (Scope.bind vs n)) -> List (Var vs)
 dropFirst = List.mapMaybe isLater
 
 ||| Manufacturing a thinning from a list of variables to keep

--- a/src/Core/TTC.idr
+++ b/src/Core/TTC.idr
@@ -1156,7 +1156,7 @@ TTC GlobalDef where
                                         mul vars vis
                                         tot hatch fl refs refsR inv c True def cdef Nothing sc Nothing)
               else pure (MkGlobalDef loc name (Erased loc Placeholder) [] [] [] []
-                                     mul ScopeEmpty (specified Public) unchecked False [] refs refsR
+                                     mul Scope.empty (specified Public) unchecked False [] refs refsR
                                      False False True def cdef Nothing [] Nothing)
 
 export

--- a/src/Core/Termination/CallGraph.idr
+++ b/src/Core/Termination/CallGraph.idr
@@ -172,7 +172,7 @@ mutual
   sizeCompare fuel s@(Meta n _ i args) t = do
     Just gdef <- lookupCtxtExact (Resolved i) (gamma defs) | _ => pure Unknown
     let (PMDef _ [] (STerm _ tm) _ _) = definition gdef | _ => pure Unknown
-    tm <- substMeta (embed tm) args zero ScopeEmpty
+    tm <- substMeta (embed tm) args zero Subst.empty
     sizeCompare fuel tm t
     where
       substMeta : {0 drop, vs : _} ->

--- a/src/Core/Unify.idr
+++ b/src/Core/Unify.idr
@@ -284,7 +284,7 @@ unifyArgs mode loc env _ _ = ufail loc ""
 -- We use this to check that the pattern unification rule is applicable
 -- when solving a metavariable applied to arguments
 getVars : {vars : _} ->
-          List Nat -> Scopeable (NF vars) -> Maybe (Scopeable (Var vars))
+          List Nat -> List (NF vars) -> Maybe (List (Var vars))
 getVars got [] = Just []
 getVars got (NErased fc (Dotted t) :: xs) = getVars got (t :: xs)
 getVars got (NApp fc (NLocal r idx v) [] :: xs)
@@ -304,9 +304,9 @@ getVars _ (_ :: xs) = Nothing
 -- Make a sublist representing the variables used in the application.
 -- We'll use this to ensure that local variables which appear in a term
 -- are all arguments to a metavariable application for pattern unification
-toThin : (vars : Scope) -> Scopeable (Var vars) ->
+toThin : (vars : Scope) -> List (Var vars) ->
             (newvars ** Thin newvars vars)
-toThin [] xs = (ScopeEmpty ** Refl)
+toThin [] xs = (Scope.empty ** Refl)
 toThin (n :: ns) xs
      -- If there's a proof 'First' in 'xs', then 'n' should be kept,
      -- otherwise dropped
@@ -317,7 +317,7 @@ toThin (n :: ns) xs
               then (_ ** Keep svs)
               else (_ ** Drop svs)
   where
-    anyFirst : Scopeable (Var (n :: ns)) -> Bool
+    anyFirst : List (Var (n :: ns)) -> Bool
     anyFirst [] = False
     anyFirst (MkVar First :: xs) = True
     anyFirst (MkVar (Later p) :: xs) = anyFirst xs
@@ -325,7 +325,7 @@ toThin (n :: ns) xs
 -- Update the variable list to point into the sub environment
 -- (All of these will succeed because the Thin we have comes from
 -- the list of variable uses! It's not stated in the type, though.)
-updateVars : Scopeable (Var {a = Name} vars) -> Thin newvars vars -> Scopeable (Var newvars)
+updateVars : List (Var {a = Name} vars) -> Thin newvars vars -> List (Var newvars)
 updateVars vs th = mapMaybe (\ v => shrink v th) vs
 
 {- Applying the pattern unification rule is okay if:
@@ -346,8 +346,8 @@ updateVars vs th = mapMaybe (\ v => shrink v th) vs
 patternEnv : {auto c : Ref Ctxt Defs} ->
              {auto u : Ref UST UState} ->
              {vars : _} ->
-             Env Term vars -> Scopeable (Closure vars) ->
-             Core (Maybe (newvars ** (Scopeable (Var newvars),
+             Env Term vars -> List (Closure vars) ->
+             Core (Maybe (newvars ** (List (Var newvars),
                                      Thin newvars vars)))
 patternEnv {vars} env args
     = do defs <- get Ctxt
@@ -360,7 +360,7 @@ patternEnv {vars} env args
                let (newvars ** svs) = toThin _ vs in
                  Just (newvars ** (updateVars vs svs, svs))
 
-getVarsTm : List Nat -> Scopeable (Term vars) -> Maybe (Scopeable (Var vars))
+getVarsTm : List Nat -> List (Term vars) -> Maybe (List (Var vars))
 getVarsTm got [] = Just []
 getVarsTm got (Local fc r idx v :: xs)
     = if idx `elem` got then Nothing
@@ -372,8 +372,8 @@ export
 patternEnvTm : {auto c : Ref Ctxt Defs} ->
                {auto u : Ref UST UState} ->
                {vars : _} ->
-               Env Term vars -> Scopeable (Term vars) ->
-               Core (Maybe (newvars ** (Scopeable (Var newvars),
+               Env Term vars -> List (Term vars) ->
+               Core (Maybe (newvars ** (List (Var newvars),
                                        Thin newvars vars)))
 patternEnvTm {vars} env args
     = do defs <- get Ctxt
@@ -421,8 +421,11 @@ occursCheck fc env mode mname tm
 
 -- How the variables in a metavariable definition map to the variables in
 -- the solution term (the Var newvars)
-data IVars : Scope -> Scope -> Type where
-     INil : IVars ScopeEmpty newvars
+--
+-- TODO factor out as a renaming
+-- TODO use `All` "quantifier"
+data IVars : Scope -> Scoped where
+     INil : IVars Scope.empty newvars
      ICons : Maybe (Var newvars) -> IVars vs newvars ->
              IVars (v :: vs) newvars
 
@@ -456,7 +459,7 @@ tryInstantiate {newvars} loc mode env mname mref num mdef locs otm tm
               PV pv pi => throw (PatternVariableUnifies loc (getLoc otm) env (PV pv pi) otm)
               _ => pure ()
          defs <- get Ctxt
-         ty <- normalisePis defs ScopeEmpty $ type mdef
+         ty <- normalisePis defs Env.empty $ type mdef
                      -- make sure we have all the pi binders we need in the
                      -- type to make the metavariable definition
          logTerm "unify.instantiate" 5 ("Type: " ++ show mname) (type mdef)
@@ -476,7 +479,7 @@ tryInstantiate {newvars} loc mode env mname mref num mdef locs otm tm
                                      (not (isUserName mname) && isSimple rhs)
                                      False
          let newdef = { definition :=
-                          PMDef simpleDef ScopeEmpty (STerm 0 rhs) (STerm 0 rhs) []
+                          PMDef simpleDef Scope.empty (STerm 0 rhs) (STerm 0 rhs) []
                       } mdef
          ignore $ addDef (Resolved mref) newdef
          removeHole mref
@@ -657,8 +660,8 @@ mutual
 
   getArgTypes : {vars : _} ->
                 {auto c : Ref Ctxt Defs} ->
-                Defs -> (fnType : NF vars) -> Scopeable (Closure vars) ->
-                Core (Maybe (Scopeable (NF vars)))
+                Defs -> (fnType : NF vars) -> List (Closure vars) ->
+                Core (Maybe (List (NF vars)))
   getArgTypes defs (NBind _ n (Pi _ _ _ ty) sc) (a :: as)
      = do Just scTys <- getArgTypes defs !(sc defs a) as
                | Nothing => pure Nothing
@@ -671,7 +674,7 @@ mutual
                  {auto u : Ref UST UState} ->
                  UnifyInfo ->
                  FC -> Env Term vars ->
-                 Maybe (Scopeable (NF vars)) -> Maybe (Scopeable (NF vars)) ->
+                 Maybe (List (NF vars)) -> Maybe (List (NF vars)) ->
                  Core Bool
   headsConvert mode fc env (Just vs) (Just ns)
       = case (reverse vs, reverse ns) of
@@ -693,11 +696,11 @@ mutual
                     (swaporder : Bool) ->
                     UnifyInfo -> FC -> Env Term vars ->
                     (metaname : Name) -> (metaref : Int) ->
-                    (margs : Scopeable (Closure vars)) ->
-                    (margs' : Scopeable (Closure vars)) ->
+                    (margs : List (Closure vars)) ->
+                    (margs' : List (Closure vars)) ->
                     Maybe ClosedTerm ->
-                    (Scopeable (FC, Closure vars) -> NF vars) ->
-                    Scopeable (FC, Closure vars) ->
+                    (List (FC, Closure vars) -> NF vars) ->
+                    List (FC, Closure vars) ->
                     Core UnifyResult
   unifyInvertible swap mode fc env mname mref margs margs' nty con args'
       = do defs <- get Ctxt
@@ -753,8 +756,8 @@ mutual
                  (swaporder : Bool) ->
                  UnifyInfo -> FC -> Env Term vars ->
                  (metaname : Name) -> (metaref : Int) ->
-                 (margs : Scopeable (Closure vars)) ->
-                 (margs' : Scopeable (Closure vars)) ->
+                 (margs : List (Closure vars)) ->
+                 (margs' : List (Closure vars)) ->
                  NF vars ->
                  Core UnifyResult
   unifyHoleApp swap mode loc env mname mref margs margs' (NTCon nfc n t a args')
@@ -793,8 +796,8 @@ mutual
                    (swaporder : Bool) ->
                    UnifyInfo -> FC -> Env Term vars ->
                    (metaname : Name) -> (metaref : Int) ->
-                   (margs : Scopeable (Closure vars)) ->
-                   (margs' : Scopeable (Closure vars)) ->
+                   (margs : List (Closure vars)) ->
+                   (margs' : List (Closure vars)) ->
                    (soln : NF vars) ->
                    Core UnifyResult
   postponePatVar swap mode loc env mname mref margs margs' tm
@@ -810,9 +813,9 @@ mutual
               {newvars, vars : _} ->
               FC -> UnifyInfo -> Env Term vars ->
               (metaname : Name) -> (metaref : Int) ->
-              (margs : Scopeable (Closure vars)) ->
-              (margs' : Scopeable (Closure vars)) ->
-              Scopeable (Var newvars) ->
+              (margs : List (Closure vars)) ->
+              (margs' : List (Closure vars)) ->
+              List (Var newvars) ->
               Thin newvars vars ->
               (solfull : Term vars) -> -- Original solution
               (soln : Term newvars) -> -- Solution with shrunk environment
@@ -855,8 +858,8 @@ mutual
               (swaporder : Bool) ->
               UnifyInfo -> FC -> Env Term vars ->
               FC -> (metaname : Name) -> (metaref : Int) ->
-              (args : Scopeable (Closure vars)) ->
-              (args' : Scopeable (Closure vars)) ->
+              (args : List (Closure vars)) ->
+              (args' : List (Closure vars)) ->
               (soln : NF vars) ->
               Core UnifyResult
   unifyHole swap mode loc env fc mname mref margs margs' tmnf
@@ -921,7 +924,7 @@ mutual
              (swaporder : Bool) -> -- swap the order when postponing
                                    -- (this is to preserve second arg being expected type)
              UnifyInfo -> FC -> Env Term vars -> FC ->
-             NHead vars -> Scopeable (FC, Closure vars) -> NF vars ->
+             NHead vars -> List (FC, Closure vars) -> NF vars ->
              Core UnifyResult
   unifyApp swap mode loc env fc (NMeta n i margs) args tm
       = unifyHole swap mode loc env fc n i margs (map snd args) tm
@@ -940,8 +943,8 @@ mutual
       = do gam <- get Ctxt
            if x == y then pure success
              else postponeS swap loc mode "Postponing var"
-                            env (NApp xfc (NLocal rx x xp) ScopeEmpty)
-                                (NApp yfc (NLocal ry y yp) ScopeEmpty)
+                            env (NApp xfc (NLocal rx x xp) [])
+                                (NApp yfc (NLocal ry y yp) [])
   -- A local against something canonical (binder or constructor) is bad
   unifyApp swap mode loc env xfc (NLocal rx x xp) args y@(NBind _ _ _ _)
       = convertErrorS swap loc env (NApp xfc (NLocal rx x xp) args) y
@@ -972,14 +975,14 @@ mutual
                   {auto u : Ref UST UState} ->
                   {vars : _} ->
                   UnifyInfo -> FC -> Env Term vars ->
-                  FC -> NHead vars -> Scopeable (FC, Closure vars) ->
-                  FC -> NHead vars -> Scopeable (FC, Closure vars) ->
+                  FC -> NHead vars -> List (FC, Closure vars) ->
+                  FC -> NHead vars -> List (FC, Closure vars) ->
                   Core UnifyResult
   unifyBothApps mode loc env xfc (NLocal xr x xp) [] yfc (NLocal yr y yp) []
       = if x == y
            then pure success
-           else convertError loc env (NApp xfc (NLocal xr x xp) ScopeEmpty)
-                                     (NApp yfc (NLocal yr y yp) ScopeEmpty)
+           else convertError loc env (NApp xfc (NLocal xr x xp) [])
+                                     (NApp yfc (NLocal yr y yp) [])
   -- Locally bound things, in a term (not LHS). Since we have to unify
   -- for *all* possible values, we can safely unify the arguments.
   unifyBothApps mode@(MkUnifyInfo p InTerm) loc env xfc (NLocal xr x xp) xargs yfc (NLocal yr y yp) yargs
@@ -1018,7 +1021,7 @@ mutual
       pv (PV _ _) = True
       pv _ = False
 
-      localsIn : Scopeable (Closure vars) -> Core Nat
+      localsIn : List (Closure vars) -> Core Nat
       localsIn [] = pure 0
       localsIn (c :: cs)
           = do defs <- get Ctxt
@@ -1442,9 +1445,9 @@ retryGuess mode smode (hid, (loc, hname))
                BySearch rig depth defining =>
                   handleUnify
                      (do tm <- search loc rig (smode == Defaults) depth defining
-                                      (type def) ScopeEmpty
-                         let gdef = { definition := PMDef defaultPI ScopeEmpty (STerm 0 tm) (STerm 0 tm) [] } def
-                         logTermNF "unify.retry" 5 ("Solved " ++ show hname) ScopeEmpty tm
+                                      (type def) Env.empty
+                         let gdef = { definition := PMDef defaultPI Scope.empty (STerm 0 tm) (STerm 0 tm) [] } def
+                         logTermNF "unify.retry" 5 ("Solved " ++ show hname) Env.empty tm
                          ignore $ addDef (Resolved hid) gdef
                          removeGuess hid
                          pure True)
@@ -1458,13 +1461,13 @@ retryGuess mode smode (hid, (loc, hname))
                        err =>
                          do logTermNF "unify.retry" 5
                                       ("Search failed at " ++ show rig ++ " for " ++ show hname)
-                                      ScopeEmpty (type def)
+                                      Env.empty (type def)
                             case smode of
                                  LastChance => throw err
                                  _ => if recoverable err
                                          then pure False -- Postpone again
                                          else throw (CantSolveGoal loc (gamma defs)
-                                                        ScopeEmpty (type def) (Just err))
+                                                        Env.empty (type def) (Just err))
                Guess tm envb [constr] =>
                  do let umode = case smode of
                                      MatchArgs => inMatch
@@ -1475,11 +1478,11 @@ retryGuess mode smode (hid, (loc, hname))
                                            NoLazy => pure tm
                                            AddForce r => pure $ forceMeta r envb tm
                                            AddDelay r =>
-                                              do ty <- getType ScopeEmpty tm
+                                              do ty <- getType Env.empty tm
                                                  logTerm "unify.retry" 5 "Retry Delay" tm
                                                  pure $ delayMeta r envb !(getTerm ty) tm
                                   let gdef = { definition := PMDef (MkPMDefInfo NotHole True False)
-                                                                   ScopeEmpty (STerm 0 tm') (STerm 0 tm') [] } def
+                                                                   Scope.empty (STerm 0 tm') (STerm 0 tm') [] } def
                                   logTerm "unify.retry" 5 ("Resolved " ++ show hname) tm'
                                   ignore $ addDef (Resolved hid) gdef
                                   removeGuess hid
@@ -1488,7 +1491,7 @@ retryGuess mode smode (hid, (loc, hname))
                                            NoLazy => pure tm
                                            AddForce r => pure $ forceMeta r envb tm
                                            AddDelay r =>
-                                              do ty <- getType ScopeEmpty tm
+                                              do ty <- getType Env.empty tm
                                                  logTerm "unify.retry" 5 "Retry Delay (constrained)" tm
                                                  pure $ delayMeta r envb !(getTerm ty) tm
                                      let gdef = { definition := Guess tm' envb newcs } def
@@ -1505,7 +1508,7 @@ retryGuess mode smode (hid, (loc, hname))
                          -- proper definition and remove it from the
                          -- hole list
                          [] => do let gdef = { definition := PMDef (MkPMDefInfo NotHole True False)
-                                                                   ScopeEmpty (STerm 0 tm) (STerm 0 tm) [] } def
+                                                                   Scope.empty (STerm 0 tm) (STerm 0 tm) [] } def
                                   logTerm "unify.retry" 5 ("Resolved " ++ show hname) tm
                                   ignore $ addDef (Resolved hid) gdef
                                   removeGuess hid
@@ -1583,7 +1586,7 @@ checkArgsSame (x :: xs)
              Just (PMDef _ [] (STerm 0 def) _ _) <-
                         lookupDefExact (Resolved t) (gamma defs)
                  | _ => anySame tm ts
-             if !(convert defs ScopeEmpty tm def)
+             if !(convert defs Env.empty tm def)
                 then pure True
                 else anySame tm ts
 
@@ -1601,7 +1604,7 @@ checkDots
     getHoleName : ClosedTerm -> Core (Maybe Name)
     getHoleName tm
         = do defs <- get Ctxt
-             NApp _ (NMeta n' i args) _ <- nf defs ScopeEmpty tm
+             NApp _ (NMeta n' i args) _ <- nf defs Env.empty tm
                  | _ => pure Nothing
              pure (Just n')
 
@@ -1655,7 +1658,7 @@ checkDots
                            do defs <- get Ctxt
                               Just dty <- lookupTyExact n (gamma defs)
                                    | Nothing => undefinedName fc n
-                              logTermNF "unify.constraint" 5 "Dot type" ScopeEmpty dty
+                              logTermNF "unify.constraint" 5 "Dot type" Env.empty dty
                               -- Clear constraints so we don't report again
                               -- later
                               put UST ({ dotConstraints := [] } ust)

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -5,6 +5,8 @@ import Core.Core
 import Core.Env
 import Core.TT
 
+import Data.List.Quantifiers
+
 %default covering
 
 public export
@@ -56,10 +58,10 @@ cbv : EvalOpts
 cbv = { strategy := CBV } defaultOpts
 
 mutual
+  -- TODO swap arguments and type as `Scope -> Scoped`
   public export
-  data LocalEnv : Scope -> Scope -> Type where
-       Nil  : LocalEnv free []
-       (::) : Closure free -> LocalEnv free vars -> LocalEnv free (x :: vars)
+  LocalEnv : Scope -> Scope -> Type
+  LocalEnv free = All (\_ => Closure free)
 
   public export
   data Closure : Scoped where
@@ -115,9 +117,10 @@ public export
 ClosedNF : Type
 ClosedNF = NF []
 
-public export
-ScopeEmpty : LocalEnv free []
-ScopeEmpty = []
+namespace LocalEnv
+  public export
+  empty : LocalEnv free []
+  empty = []
 
 export
 ntCon : FC -> Name -> Int -> Nat -> List (FC, Closure vars) -> NF vars

--- a/src/Core/Value.idr
+++ b/src/Core/Value.idr
@@ -69,7 +69,7 @@ mutual
                    (opts : EvalOpts) ->
                    LocalEnv free vars ->
                    Env Term free ->
-                   Term (AddInner free vars) -> Closure free
+                   Term (Scope.addInner free vars) -> Closure free
        MkNFClosure : EvalOpts -> Env Term free -> NF free -> Closure free
 
   -- The head of a value: things you can apply arguments to

--- a/src/Idris/Doc/Display.idr
+++ b/src/Idris/Doc/Display.idr
@@ -24,13 +24,13 @@ displayType : {auto c : Ref Ctxt Defs} ->
               (shortName : Bool) -> Defs -> (Name, Int, GlobalDef) ->
               Core (Doc IdrisSyntax)
 displayType shortName defs (n, i, gdef)
-  = maybe (do tm <- resugar ScopeEmpty !(normaliseHoles defs ScopeEmpty (type gdef))
+  = maybe (do tm <- resugar Env.empty !(normaliseHoles defs Env.empty (type gdef))
               nm <- aliasName (fullname gdef)
               let nm = ifThenElse shortName (dropNS nm) nm
               let prig = prettyRig gdef.multiplicity
               let ann = showCategory id gdef
               pure (prig <+> ann (cast $ prettyOp True nm) <++> colon <++> pretty tm))
-          (\num => prettyHole defs ScopeEmpty n num (type gdef))
+          (\num => prettyHole defs Env.empty n num (type gdef))
           (isHole gdef)
 export
 displayTerm : {auto c : Ref Ctxt Defs} ->
@@ -38,7 +38,7 @@ displayTerm : {auto c : Ref Ctxt Defs} ->
               Defs -> ClosedTerm ->
               Core (Doc IdrisSyntax)
 displayTerm defs tm
-  = do ptm <- resugar ScopeEmpty !(normaliseHoles defs ScopeEmpty tm)
+  = do ptm <- resugar Env.empty !(normaliseHoles defs Env.empty tm)
        pure (pretty ptm)
 
 export

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -139,8 +139,8 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
          -- The interface name might be qualified, so check if it's an
          -- alias for something
          syn <- get Syn
-         defs <- get Ctxt
-         let varsList = toList vars
+         s <- get Ctxt
+         let varsList = toList vars -- TODO change list in findBindableNames?
          inames <- lookupCtxtName iname (gamma defs)
          let [cndata] = concatMap (\n => lookupName n (ifaces syn))
                                   (map fst inames)

--- a/src/Idris/Elab/Implementation.idr
+++ b/src/Idris/Elab/Implementation.idr
@@ -28,6 +28,7 @@ import Libraries.Data.NameMap
 
 %default covering
 
+-- TODO move out of file, maybe make `show` instance for `FC` platform-independent
 replaceSep : String -> String
 replaceSep = pack . map toForward . unpack
   where
@@ -139,7 +140,7 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
          -- The interface name might be qualified, so check if it's an
          -- alias for something
          syn <- get Syn
-         s <- get Ctxt
+         defs <- get Ctxt
          let varsList = toList vars -- TODO change list in findBindableNames?
          inames <- lookupCtxtName iname (gamma defs)
          let [cndata] = concatMap (\n => lookupName n (ifaces syn))
@@ -203,10 +204,10 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
                                       (IBindHere vfc (PI erased) impTy)
                                       (Just (gType vfc u))
                    let fullty = abstractFullEnvType vfc env ty
-                   ok <- convert defs ScopeEmpty fullty (type gdef)
-                   unless ok $ do logTermNF "elab.implementation" 1 "Previous" ScopeEmpty (type gdef)
-                                  logTermNF "elab.implementation" 1 "Now" ScopeEmpty fullty
-                                  throw (CantConvert (getFC impTy) (gamma defs) ScopeEmpty fullty (type gdef))
+                   ok <- convert defs Env.empty fullty (type gdef)
+                   unless ok $ do logTermNF "elab.implementation" 1 "Previous" Env.empty (type gdef)
+                                  logTermNF "elab.implementation" 1 "Now" Env.empty fullty
+                                  throw (CantConvert (getFC impTy) (gamma defs) Env.empty fullty (type gdef))
 
          -- If the body is empty, we're done for now (just declaring that
          -- the implementation exists and define it later)
@@ -215,7 +216,7 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
                defs <- get Ctxt
                Just impTyc <- lookupTyExact impName (gamma defs)
                     | Nothing => throw (InternalError ("Can't happen, can't find type of " ++ show impName))
-               methImps <- getMethImps ScopeEmpty impTyc
+               methImps <- getMethImps Env.empty impTyc
                log "elab.implementation" 3 $ "Bind implicits to each method: " ++ show methImps
 
                -- 1.5. Lookup default definitions and add them to the body
@@ -255,7 +256,7 @@ elabImplementation {vars} ifc vis opts_in pass env nest is cons iname ps named i
                -- RHS is the constructor applied to a search for the necessary
                -- parent constraints, then the method implementations
                defs <- get Ctxt
-               let fldTys = getFieldArgs !(normaliseHoles defs ScopeEmpty conty)
+               let fldTys = getFieldArgs !(normaliseHoles defs Env.empty conty)
                log "elab.implementation" 5 $ "Field types " ++ show fldTys
                let irhs = apply (autoImpsApply (IVar vfc con) $ map (const (ISearch vfc 500)) (parents cdata))
                                   (map (mkMethField methImps fldTys) fns)

--- a/src/Idris/Elab/Interface.idr
+++ b/src/Idris/Elab/Interface.idr
@@ -520,6 +520,6 @@ elabInterface {vars} ifc def_vis env nest constraints iname params dets mcon bod
                                                  meth_names
                                                  params) nconstraints
              log "elab.interface" 5 $ "Constraint hints from " ++ show constraints ++ ": " ++ show chints
-             Core.Core.traverse_ (processDecl [] nest env) (concatMap snd chints)
+             List.traverse_ (processDecl [] nest env) (concatMap snd chints)
              traverse_ (\n => do mn <- inCurrentNS n
                                  setFlag vfc mn TCInline) (map fst chints)

--- a/src/Idris/Error.idr
+++ b/src/Idris/Error.idr
@@ -392,7 +392,7 @@ perrorRaw (NotCovering fc n (MissingCases cs))
     = pure $ errorDesc (code (pretty0 !(prettyName n)) <++> reflow "is not covering.")
         <+> line <+> !(ploc fc) <+> line
         <+> reflow "Missing cases" <+> colon <+> line
-        <+> indent 4 (vsep !(traverse (pshow ScopeEmpty) cs)) <+> line
+        <+> indent 4 (vsep !(traverse (pshow Env.empty) cs)) <+> line
 perrorRaw (NotCovering fc n (NonCoveringCall ns))
     = pure $ errorDesc (pretty0 !(prettyName n) <++> reflow "is not covering.")
         <+> line <+> !(ploc fc) <+> line

--- a/src/Idris/IDEMode/CaseSplit.idr
+++ b/src/Idris/IDEMode/CaseSplit.idr
@@ -382,7 +382,7 @@ getClause l n
          Just (loc, nidx, envlen, ty) <- findTyDeclAt (\p, n => onLine (l-1) p)
              | Nothing => pure Nothing
          n <- getFullName nidx
-         argns <- getEnvArgNames defs envlen !(nf defs ScopeEmpty ty)
+         argns <- getEnvArgNames defs envlen !(nf defs Env.empty ty)
          Just srcLine <- getSourceLine l
            | Nothing => pure Nothing
          let (mark, src) = isLitLine srcLine

--- a/src/Idris/IDEMode/Holes.idr
+++ b/src/Idris/IDEMode/Holes.idr
@@ -155,7 +155,7 @@ getUserHolesData
          traverse (\n_gdef_args =>
                      -- Inference can't deal with this for now :/
                      let (n, gdef, args) = the (Name, GlobalDef, Nat) n_gdef_args in
-                     holeData defs ScopeEmpty n args (type gdef))
+                     holeData defs Env.empty n args (type gdef))
                   holesWithArgs
 
 export

--- a/src/Idris/Parser.idr
+++ b/src/Idris/Parser.idr
@@ -1115,7 +1115,7 @@ mutual
           let fc = boundToFC fname x in
           toLines xs [< StrLiteral fc (last strs)]
             $ acc :< (line <>> [StrLiteral fc str])
-            <>< (the (List _) $ map (\str => [StrLiteral fc str]) (init strs))
+            <>< map (\str => [StrLiteral fc str]) (init strs)
 
   fnDirectOpt : OriginDesc -> Rule PFnOpt
   fnDirectOpt fname

--- a/src/Idris/ProcessIdr.idr
+++ b/src/Idris/ProcessIdr.idr
@@ -88,7 +88,7 @@ processDecl (MkFCVal _ $ PMutual ps)
 
 processDecl decl
     = catch (do impdecls <- desugarDecl [] decl
-                traverse_ (Check.processDecl [] (MkNested []) ScopeEmpty) impdecls
+                traverse_ (Check.processDecl [] (MkNested []) Env.empty) impdecls
                 pure [])
             (\err => do giveUpConstraints -- or we'll keep trying...
                         pure [err])

--- a/src/Idris/REPL/Common.idr
+++ b/src/Idris/REPL/Common.idr
@@ -258,7 +258,7 @@ docsOrSignature fc n
     typeSummary : Defs -> Core (Doc IdrisDocAnn)
     typeSummary defs = do Just def <- lookupCtxtExact n (gamma defs)
                             | Nothing => pure ""
-                          ty <- resugar ScopeEmpty !(normaliseHoles defs ScopeEmpty (type def))
+                          ty <- resugar Env.empty !(normaliseHoles defs Env.empty (type def))
                           pure $ pretty0 n <++> ":" <++> prettyBy Syntax ty
 
 export
@@ -271,11 +271,11 @@ equivTypes ty1 ty2 =
           | _ => pure False
      logTerm "typesearch.equiv" 10 "Candidate: " ty1
      defs <- get Ctxt
-     True <- pure (!(getArity defs ScopeEmpty ty1) == !(getArity defs ScopeEmpty ty2))
+     True <- pure (!(getArity defs Env.empty ty1) == !(getArity defs Env.empty ty2))
        | False => pure False
      _ <- newRef UST initUState
      b <- catch
-           (do res <- unify inTerm EmptyFC ScopeEmpty ty1 ty2
+           (do res <- unify inTerm EmptyFC Env.empty ty1 ty2
                case res of
                  (MkUnifyResult [] _ [] NoLazy) => pure True
                  _ => pure False)

--- a/src/Libraries/Data/List/Quantifiers/Extra.idr
+++ b/src/Libraries/Data/List/Quantifiers/Extra.idr
@@ -25,3 +25,15 @@ export
 tabulate : ((x : a) -> p x) -> (xs : List a) -> All p xs
 tabulate f [] = []
 tabulate f (x :: xs) = f x :: tabulate f xs
+
+-- TODO: delete this function after 0.7.1 is released
+-- as it now exists in base's Data.List.Quantifiers
+export
+head : All p (x :: xs) -> p x
+head (px :: _) = px
+
+-- TODO: delete this function after 0.7.1 is released
+-- as it now exists in base's Data.List.Quantifiers
+export
+tail : All p (x :: xs) -> All p xs
+tail (_ :: pxs) = pxs

--- a/src/Libraries/Data/SnocList/Extra.idr
+++ b/src/Libraries/Data/SnocList/Extra.idr
@@ -4,10 +4,14 @@ import Data.Nat
 import Data.SnocList
 import Syntax.PreorderReasoning
 
+-- TODO left-to-right reversal of the stream
+--      is this what we want?
+{-
 public export
 take : (n : Nat) -> (xs : Stream a) -> SnocList a
 take Z xs = [<]
 take (S k) (x :: xs) = take k xs :< x
+-}
 
 public export
 snocAppendFishAssociative :

--- a/src/Libraries/Data/SnocList/HasLength.idr
+++ b/src/Libraries/Data/SnocList/HasLength.idr
@@ -25,9 +25,13 @@ hasLength Z = Refl
 hasLength (S p) = cong S (hasLength p)
 
 export
-sucR : HasLength n sx -> HasLength (S n) ([<x] ++ sx)
-sucR Z     = S Z
-sucR (S n) = S (sucR n)
+sucR : HasLength n sx -> HasLength (S n) (sx ++ [<x])
+sucR = S
+
+export
+sucL : HasLength n sx -> HasLength (S n) ([<x] ++ sx)
+sucL Z     = S Z
+sucL (S n) = S (sucL n)
 
 export
 hlAppend : HasLength m sx -> HasLength n sy -> HasLength (n + m) (sx ++ sy)
@@ -51,11 +55,12 @@ hlChips {m = S m} {n} (S x) y
   = rewrite plusSuccRightSucc m n in
     hlChips x (S y)
 
+{-
 export
 take : (n : Nat) -> (xs : Stream a) -> HasLength n (take n xs)
 take Z _ = Z
 take (S n) (x :: xs) = S (take n xs)
-
+-}
 
 export
 cast : {sy : _} -> (0 _ : SnocList.length sx = SnocList.length sy) ->

--- a/src/Libraries/Data/SnocList/SizeOf.idr
+++ b/src/Libraries/Data/SnocList/SizeOf.idr
@@ -47,8 +47,8 @@ suc (MkSizeOf n p) = MkSizeOf (S n) (S p)
 
 -- ||| suc but from the right
 export
-sucR : SizeOf as -> SizeOf ([<a] ++ as)
-sucR (MkSizeOf n p) = MkSizeOf (S n) (sucR p)
+sucL : SizeOf as -> SizeOf ([<a] ++ as)
+sucL (MkSizeOf n p) = MkSizeOf (S n) (sucL p)
 
 public export
 (<><) : SizeOf {a} sx -> LSizeOf {a} ys -> SizeOf (sx <>< ys)
@@ -82,9 +82,11 @@ map (MkSizeOf n p) = MkSizeOf n (cast (sym $ lengthMap sx) p) where
   lengthMap [<] = Refl
   lengthMap (sx :< x) = cong S (lengthMap sx)
 
+{-
 public export
 take : {n : Nat} -> {0 sx : Stream a} -> SizeOf (take n sx)
 take = MkSizeOf n (take n sx)
+-}
 
 namespace SizedView
 

--- a/src/TTImp/Elab.idr
+++ b/src/TTImp/Elab.idr
@@ -69,8 +69,8 @@ normaliseHoleTypes
   where
     updateType : Defs -> Int -> GlobalDef -> Core ()
     updateType defs i def
-        = do ty' <- catch (tryNormaliseSizeLimit defs 10 ScopeEmpty (type def))
-                          (\err => normaliseHoles defs ScopeEmpty (type def))
+        = do ty' <- catch (tryNormaliseSizeLimit defs 10 Env.empty (type def))
+                          (\err => normaliseHoles defs Env.empty (type def))
              ignore $ addDef (Resolved i) ({ type := ty' } def)
 
     normaliseH : Defs -> Int -> Core ()

--- a/src/TTImp/Elab/Ambiguity.idr
+++ b/src/TTImp/Elab/Ambiguity.idr
@@ -221,7 +221,7 @@ mutual
                {vars : _} ->
                Defs -> NF vars -> ClosedNF -> Core TypeMatch
   mightMatch defs target (NBind fc n (Pi _ _ _ _) sc)
-      = mightMatchD defs target !(sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder)))
+      = mightMatchD defs target !(sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder)))
   mightMatch defs (NBind _ _ _ _) (NBind _ _ _ _) = pure Poly -- lambdas might match
   mightMatch defs (NTCon _ n t a args) (NTCon _ n' t' a' args')
       = if n == n'
@@ -249,7 +249,7 @@ couldBeName : {auto c : Ref Ctxt Defs} ->
 couldBeName defs target n
     = case !(lookupTyExact n (gamma defs)) of
            Nothing => pure Poly -- could be a local name, don't rule it out
-           Just ty => mightMatchD defs target !(nf defs ScopeEmpty ty)
+           Just ty => mightMatchD defs target !(nf defs Env.empty ty)
 
 couldBeFn : {auto c : Ref Ctxt Defs} ->
             {vars : _} ->

--- a/src/TTImp/Elab/Check.idr
+++ b/src/TTImp/Elab/Check.idr
@@ -242,7 +242,7 @@ strengthenedEState {n} {vars} c e fc env
     -- never actualy *use* that hole - this process is only to ensure that the
     -- unbound implicit doesn't depend on any variables it doesn't have
     -- in scope.
-    removeArgVars : Scopeable (Term (n :: vs)) -> Maybe (Scopeable (Term vs))
+    removeArgVars : List (Term (n :: vs)) -> Maybe (List (Term vs))
     removeArgVars [] = pure []
     removeArgVars (Local fc r (S k) p :: args)
         = do args' <- removeArgVars args
@@ -416,7 +416,7 @@ uniVar : {auto c : Ref Ctxt Defs} ->
          FC -> Core Name
 uniVar fc
     = do n <- genName "u"
-         idx <- addDef n (newDef fc n erased ScopeEmpty (Erased fc Placeholder) (specified Public) None)
+         idx <- addDef n (newDef fc n erased Scope.empty (Erased fc Placeholder) (specified Public) None)
          pure (Resolved idx)
 
 export
@@ -456,7 +456,7 @@ searchVar fc rig depth def env nest n ty
 
     envHints : List Name -> Env Term vars ->
                Core (vars' ** (Term (vars' ++ vars) -> Term vars, Env Term (vars' ++ vars)))
-    envHints [] env = pure (ScopeEmpty ** (id, env))
+    envHints [] env = pure (Scope.empty ** (id, env))
     envHints (n :: ns) env
         = do (vs ** (f, env')) <- envHints ns env
              let Just (nestn, argns, tmf) = find !(toFullNames n) (names nest)

--- a/src/TTImp/Elab/Delayed.idr
+++ b/src/TTImp/Elab/Delayed.idr
@@ -259,9 +259,9 @@ retryDelayed' errmode p acc (d@(_, i, hints, elab) :: ds)
 
                updateDef (Resolved i) (const (Just
                     (PMDef (MkPMDefInfo NotHole True False)
-                           ScopeEmpty (STerm 0 tm) (STerm 0 tm) [])))
+                           Scope.empty (STerm 0 tm) (STerm 0 tm) [])))
                logTerm "elab.update" 5 ("Resolved delayed hole " ++ show i) tm
-               logTermNF "elab.update" 5 ("Resolved delayed hole NF " ++ show i) ScopeEmpty tm
+               logTermNF "elab.update" 5 ("Resolved delayed hole NF " ++ show i) Env.empty tm
                removeHole i
                retryDelayed' errmode True acc ds')
            (\err => do logC "elab" 5 $ do pure $ show errmode ++ ":Error in " ++ show !(getFullName (Resolved i))

--- a/src/TTImp/Elab/ImplicitBind.idr
+++ b/src/TTImp/Elab/ImplicitBind.idr
@@ -218,7 +218,7 @@ push ofc n b tm@(Bind fc (PV x i) (Pi fc' c Implicit ty) sc) -- only push past '
            Nothing => -- needs explicit pi, do nothing
                       Bind ofc n b tm
            Just ty' => Bind fc (PV x i) (Pi fc' c Implicit ty')
-                            (push ofc n (map weaken b) (swapVars {vs = ScopeEmpty} sc))
+                            (push ofc n (map weaken b) (swapVars {vs = Scope.empty} sc))
 push ofc n b tm = Bind ofc n b tm
 
 -- Move any implicit arguments as far to the left as possible - this helps

--- a/src/TTImp/Elab/Record.idr
+++ b/src/TTImp/Elab/Record.idr
@@ -32,7 +32,7 @@ getNames defs (NApp _ hd args)
     = do eargs <- traverse (evalClosure defs . snd) args
          pure $ nheadNames hd `union` concat !(traverse (getNames defs) eargs)
   where
-    nheadNames : NHead ScopeEmpty -> SortedSet Name
+    nheadNames : NHead Scope.empty -> SortedSet Name
     nheadNames (NRef Bound n) = singleton n
     nheadNames _ = empty
 getNames defs (NDCon _ _ _ _ args)
@@ -88,7 +88,7 @@ findFieldsAndTypeArgs : {auto c : Ref Ctxt Defs} ->
                         Core $ Maybe (List (String, Maybe Name, Maybe Name), SortedSet Name)
 findFieldsAndTypeArgs defs con
     = case !(lookupTyExact con (gamma defs)) of
-           Just t => pure (Just !(getExpNames empty [] !(nf defs ScopeEmpty t)))
+           Just t => pure (Just !(getExpNames empty [] !(nf defs Env.empty t)))
            _ => pure Nothing
   where
     getExpNames : SortedSet Name ->
@@ -101,8 +101,8 @@ findFieldsAndTypeArgs defs con
                             _ => Just x
              nfty <- evalClosure defs ty
              let names = !(getNames defs nfty) `union` names
-             let expNames = (nameRoot x, imp, getRecordType ScopeEmpty nfty) :: expNames
-             getExpNames names expNames !(sc defs (toClosure defaultOpts ScopeEmpty (Ref fc Bound x)))
+             let expNames = (nameRoot x, imp, getRecordType Env.empty nfty) :: expNames
+             getExpNames names expNames !(sc defs (toClosure defaultOpts Env.empty (Ref fc Bound x)))
     getExpNames names expNames nfty = pure (reverse expNames, (!(getNames defs nfty) `union` names))
 
 genFieldName : {auto u : Ref UST UState} ->

--- a/src/TTImp/Elab/RunElab.idr
+++ b/src/TTImp/Elab/RunElab.idr
@@ -160,7 +160,7 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
         pathDoesNotEscape n     ("." ::rest) = pathDoesNotEscape n rest
         pathDoesNotEscape n     (_   ::rest) = pathDoesNotEscape (S n) rest
 
-    elabCon : Defs -> String -> Scopeable (Closure vars) -> Core (NF vars)
+    elabCon : Defs -> String -> List (Closure vars) -> Core (NF vars)
     elabCon defs "Pure" [_,val]
         = do empty <- clearDefs defs
              evalClosure empty val
@@ -297,7 +297,7 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
       where
         unelabType : (Name, Int, ClosedTerm) -> Core (Name, RawImp)
         unelabType (n, _, ty)
-            = pure (n, map rawName !(unelabUniqueBinders ScopeEmpty ty))
+            = pure (n, map rawName !(unelabUniqueBinders Env.empty ty))
     elabCon defs "GetInfo" [n]
         = do n' <- evalClosure defs n
              res <- lookupNameInfo !(reify defs n') (gamma defs)
@@ -333,8 +333,8 @@ elabScript rig fc nest env script@(NDCon nfc nm t ar args) exp
              scriptRet defs.defsStack
     elabCon defs "Declare" [d]
         = do d' <- evalClosure defs d
-             decls <- reify {a=List _} defs d'
-             traverse_ (processDecl [] (MkNested []) ScopeEmpty) decls
+             decls <- reify defs d'
+             List.traverse_ (processDecl [] (MkNested []) Env.empty) decls
              scriptRet ()
     elabCon defs "ReadFile" [lk, pth]
         = do pathPrefix <- lookupDir defs !(evalClosure defs lk)

--- a/src/TTImp/Elab/Utils.idr
+++ b/src/TTImp/Elab/Utils.idr
@@ -14,6 +14,8 @@ import TTImp.TTImp
 import Data.List.Quantifiers
 import Data.SnocList
 
+import Libraries.Data.List.Quantifiers.Extra as Lib
+
 %default covering
 
 detagSafe : {auto c : Ref Ctxt Defs} ->
@@ -22,7 +24,7 @@ detagSafe defs (NTCon _ n _ _ args)
     = do Just (TCon _ _ _ _ _ _ _ (Just detags)) <- lookupDefExact n (gamma defs)
               | _ => pure False
          args' <- traverse (evalClosure defs . snd) args
-         pure $ notErased 0 detags (toList args')
+         pure $ notErased 0 detags args'
   where
     -- if any argument positions are in the detaggable set, and unerased, then
     -- detagging is safe
@@ -133,8 +135,7 @@ Usage : Scoped
 Usage = All (\_ => ArgUsed)
 
 initUsed : (xs : Scope) -> Usage xs
-initUsed [] = []
-initUsed (x :: xs) = Used0 :: initUsed xs
+initUsed = Lib.tabulate (\_ => Used0)
 
 initUsedCase : (xs : Scope) -> Usage xs
 initUsedCase [] = []

--- a/src/TTImp/Impossible.idr
+++ b/src/TTImp/Impossible.idr
@@ -25,7 +25,7 @@ match : {auto c : Ref Ctxt Defs} ->
         ClosedNF -> (Name, Int, ClosedTerm) -> Core Bool
 match nty (n, i, rty)
     = do defs <- get Ctxt
-         rtynf <- nf defs ScopeEmpty rty
+         rtynf <- nf defs Env.empty rty
          sameRet nty rtynf
   where
     sameRet : ClosedNF -> ClosedNF -> Core Bool
@@ -38,7 +38,7 @@ match nty (n, i, rty)
     sameRet (NType _ _) (NType _ _) = pure True
     sameRet nf (NBind fc _ (Pi _ _ _ _) sc)
         = do defs <- get Ctxt
-             sc' <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+             sc' <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
              sameRet nf sc'
     sameRet _ _ = pure False
 
@@ -75,14 +75,14 @@ mutual
   processArgs fn (NBind fc x (Pi _ _ Explicit ty) sc) (e :: exps) autos named
      = do e' <- mkTerm e (Just ty) [] [] []
           defs <- get Ctxt
-          processArgs (App fc fn e') !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+          processArgs (App fc fn e') !(sc defs (toClosure defaultOpts Env.empty e'))
                       exps autos named
   processArgs fn (NBind fc x (Pi _ _ Explicit ty) sc) [] autos named
      = do defs <- get Ctxt
           case findNamed x named of
             Just ((_, e), named') =>
                do e' <- mkTerm e (Just ty) [] [] []
-                  processArgs (App fc fn e') !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+                  processArgs (App fc fn e') !(sc defs (toClosure defaultOpts Env.empty e'))
                               [] autos named'
             Nothing => badClause fn [] autos named
   processArgs fn (NBind fc x (Pi _ _ Implicit ty) sc) exps autos named
@@ -90,29 +90,29 @@ mutual
           case findNamed x named of
             Nothing => do e' <- nextVar fc
                           processArgs (App fc fn e')
-                                      !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+                                      !(sc defs (toClosure defaultOpts Env.empty e'))
                                       exps autos named
             Just ((_, e), named') =>
                do e' <- mkTerm e (Just ty) [] [] []
-                  processArgs (App fc fn e') !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+                  processArgs (App fc fn e') !(sc defs (toClosure defaultOpts Env.empty e'))
                               exps autos named'
   processArgs fn (NBind fc x (Pi _ _ AutoImplicit ty) sc) exps autos named
      = do defs <- get Ctxt
           case autos of
                (e :: autos') => -- unnamed takes priority
                    do e' <- mkTerm e (Just ty) [] [] []
-                      processArgs (App fc fn e') !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+                      processArgs (App fc fn e') !(sc defs (toClosure defaultOpts Env.empty e'))
                                   exps autos' named
                [] =>
                   case findNamed x named of
                      Nothing =>
                         do e' <- nextVar fc
                            processArgs (App fc fn e')
-                                       !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+                                       !(sc defs (toClosure defaultOpts Env.empty e'))
                                        exps [] named
                      Just ((_, e), named') =>
                         do e' <- mkTerm e (Just ty) [] [] []
-                           processArgs (App fc fn e') !(sc defs (toClosure defaultOpts ScopeEmpty e'))
+                           processArgs (App fc fn e') !(sc defs (toClosure defaultOpts Env.empty e'))
                                        exps [] named'
   processArgs fn ty [] [] [] = pure fn
   processArgs fn ty exps autos named
@@ -134,7 +134,7 @@ mutual
            gdefs <- lookupNameBy id n (gamma defs)
            [(n', i, gdef)] <- dropNoMatch !(traverseOpt (evalClosure defs) mty) gdefs
               | ts => ambiguousName fc n (map fst ts)
-           tynf <- nf defs ScopeEmpty (type gdef)
+           tynf <- nf defs Env.empty (type gdef)
            -- #899 we need to make sure that type & data constructors are marked
            -- as such so that the coverage checker actually uses the matches in
            -- `impossible` branches to generate parts of the case tree.

--- a/src/TTImp/Interactive/GenerateDef.idr
+++ b/src/TTImp/Interactive/GenerateDef.idr
@@ -63,7 +63,7 @@ expandClause : {auto c : Ref Ctxt Defs} ->
                Core (Search (List ImpClause))
 expandClause loc opts n c
     = do c <- uniqueRHS c
-         Right clause <- checkClause linear Private PartialOK False n [] (MkNested []) ScopeEmpty c
+         Right clause <- checkClause linear Private PartialOK False n [] (MkNested []) Env.empty c
             | Left err => noResult -- TODO: impossible clause, do something
                                    -- appropriate
 
@@ -158,7 +158,7 @@ generateSplits loc opts fn (ImpossibleClause fc lhs) = pure []
 generateSplits loc opts fn (WithClause fc lhs rig wval prf flags cs) = pure []
 generateSplits loc opts fn (PatClause fc lhs rhs)
     = do (lhstm, _) <-
-                elabTerm fn (InLHS linear) [] (MkNested []) ScopeEmpty
+                elabTerm fn (InLHS linear) [] (MkNested []) Env.empty
                          (IBindHere loc PATTERN lhs) Nothing
          let splitnames =
                  if ltor opts then splittableNames lhs
@@ -228,7 +228,7 @@ makeDefFromType loc opts n envlen ty
          (do defs <- branch
              meta <- get MD
              ust <- get UST
-             argns <- getEnvArgNames defs envlen !(nf defs ScopeEmpty ty)
+             argns <- getEnvArgNames defs envlen !(nf defs Env.empty ty)
              -- Need to add implicit patterns for the outer environment.
              -- We won't try splitting on these
              let pre_env = replicate envlen (Implicit loc True)

--- a/src/TTImp/Interactive/Intro.idr
+++ b/src/TTImp/Interactive/Intro.idr
@@ -55,7 +55,7 @@ parameters
     ics <- for (fromMaybe [] cs) $ \ cons => do
       Just gdef <- lookupCtxtExact cons (gamma defs)
         | _ => pure Nothing
-      let nargs = lengthExplicitPi $ fst $ snd $ underPis (-1) ScopeEmpty (type gdef)
+      let nargs = lengthExplicitPi $ fst $ snd $ underPis (-1) Env.empty (type gdef)
       new_hole_names <- uniqueHoleNames defs nargs (nameRoot hole)
       let new_holes = PHole replFC True <$> new_hole_names
       let pcons = papply replFC (PRef replFC cons) new_holes

--- a/src/TTImp/Interactive/MakeLemma.idr
+++ b/src/TTImp/Interactive/MakeLemma.idr
@@ -92,5 +92,5 @@ makeLemma : {auto c : Ref Ctxt Defs} ->
             Core (RawImp, RawImp)
 makeLemma loc n nlocs ty
     = do defs <- get Ctxt
-         (args, ret) <- getArgs ScopeEmpty nlocs !(normalise defs ScopeEmpty ty)
+         (args, ret) <- getArgs Env.empty nlocs !(normalise defs Env.empty ty)
          pure (mkType loc args ret, mkApp loc n args)

--- a/src/TTImp/ProcessData.idr
+++ b/src/TTImp/ProcessData.idr
@@ -113,7 +113,7 @@ checkCon {vars} opts nest env vis tn_in tn (MkImpTy fc cn_in ty_raw)
          -- Check 'ty' returns something in the right family
          checkFamily fc cn tn env !(nf defs env ty)
          let fullty = abstractEnvType fc env ty
-         logTermNF "declare.data.constructor" 5 ("Constructor " ++ show cn) ScopeEmpty fullty
+         logTermNF "declare.data.constructor" 5 ("Constructor " ++ show cn) Env.empty fullty
 
          traverse_ addToSave (keys (getMetas ty))
          addToSave cn
@@ -124,20 +124,20 @@ checkCon {vars} opts nest env vis tn_in tn (MkImpTy fc cn_in ty_raw)
                            addHashWithNames fullty
                            log "module.hash" 15 "Adding hash for data constructor: \{show cn}"
               _ => pure ()
-         pure (MkCon fc cn !(getArity defs ScopeEmpty fullty) fullty)
+         pure (MkCon fc cn !(getArity defs Env.empty fullty) fullty)
 
 -- Get the indices of the constructor type (with non-constructor parts erased)
 getIndexPats : {auto c : Ref Ctxt Defs} ->
                ClosedTerm -> Core (List ClosedNF)
 getIndexPats tm
     = do defs <- get Ctxt
-         tmnf <- nf defs ScopeEmpty tm
+         tmnf <- nf defs Env.empty tm
          ret <- getRetType defs tmnf
          getPats defs ret
   where
     getRetType : Defs -> ClosedNF -> Core ClosedNF
     getRetType defs (NBind fc _ (Pi _ _ _ _) sc)
-        = do sc' <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+        = do sc' <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
              getRetType defs sc'
     getRetType defs t = pure t
 
@@ -158,7 +158,7 @@ getDetags fc tys
              xs => pure $ Just xs
   where
     mutual
-      disjointArgs : Scopeable ClosedNF -> Scopeable ClosedNF -> Core Bool
+      disjointArgs : List ClosedNF -> List ClosedNF -> Core Bool
       disjointArgs [] _ = pure False
       disjointArgs _ [] = pure False
       disjointArgs (a :: args) (a' :: args')
@@ -215,19 +215,19 @@ getRelevantArg : {auto c : Ref Ctxt Defs} ->
                  Core (Maybe (Bool, Nat))
 getRelevantArg defs i rel world (NBind fc _ (Pi _ rig _ val) sc)
     = branchZero (getRelevantArg defs (1 + i) rel world
-                              !(sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))))
+                              !(sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))))
                  (case !(evalClosure defs val) of
                        -- %World is never inspected, so might as well be deleted from data types,
                        -- although it needs care when compiling to ensure that the function that
                        -- returns the IO/%World type isn't erased
                        (NPrimVal _ $ PrT WorldType) =>
                            getRelevantArg defs (1 + i) rel False
-                               !(sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder)))
+                               !(sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder)))
                        _ =>
                        -- if we haven't found a relevant argument yet, make
                        -- a note of this one and keep going. Otherwise, we
                        -- have more than one, so give up.
-                           maybe (do sc' <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+                           maybe (do sc' <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
                                      getRelevantArg defs (1 + i) (Just i) False sc')
                                  (const (pure Nothing))
                                  rel)
@@ -242,7 +242,7 @@ findNewtype : {auto c : Ref Ctxt Defs} ->
               List Constructor -> Core ()
 findNewtype [con]
     = do defs <- get Ctxt
-         Just arg <- getRelevantArg defs 0 Nothing True !(nf defs ScopeEmpty (type con))
+         Just arg <- getRelevantArg defs 0 Nothing True !(nf defs Env.empty (type con))
               | Nothing => pure ()
          updateDef (name con) $
                \case
@@ -281,7 +281,7 @@ shaped : {auto c : Ref Ctxt Defs} ->
 shaped as [] = pure Nothing
 shaped as (c :: cs)
     = do defs <- get Ctxt
-         if as !(normalise defs ScopeEmpty (type c))
+         if as !(normalise defs Env.empty (type c))
             then pure (Just (name c))
             else shaped as cs
 
@@ -334,7 +334,7 @@ calcEnum fc cs
     isNullary : Constructor -> Core Bool
     isNullary c
         = do defs <- get Ctxt
-             pure $ hasArgs 0 !(normalise defs ScopeEmpty (type c))
+             pure $ hasArgs 0 !(normalise defs Env.empty (type c))
 
 calcRecord : {auto c : Ref Ctxt Defs} ->
              FC -> List Constructor -> Core Bool
@@ -421,10 +421,10 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpLater dfc n_in ty_raw)
                               (IBindHere fc (PI erased) ty_raw)
                               (Just (gType dfc u))
          let fullty = abstractEnvType dfc env ty
-         logTermNF "declare.data" 5 ("data " ++ show n) ScopeEmpty fullty
+         logTermNF "declare.data" 5 ("data " ++ show n) Env.empty fullty
 
          checkIsType fc n env !(nf defs env ty)
-         arity <- getArity defs ScopeEmpty fullty
+         arity <- getArity defs Env.empty fullty
 
          -- Add the type constructor as a placeholder
          tidx <- addDef n (newDef fc n top vars fullty def_vis
@@ -504,16 +504,16 @@ processData {vars} eopts nest env fc def_vis mbtot (MkImpData dfc n_in mty_raw o
                       TCon _ _ _ _ flags mw Nothing _ => case mfullty of
                         Nothing => pure (mw, vis, tot, type ndef)
                         Just fullty =>
-                            do ok <- convert defs ScopeEmpty fullty (type ndef)
+                            do ok <- convert defs Env.empty fullty (type ndef)
                                if ok then pure (mw, vis, tot, fullty)
-                                     else do logTermNF "declare.data" 1 "Previous" ScopeEmpty (type ndef)
-                                             logTermNF "declare.data" 1 "Now" ScopeEmpty fullty
+                                     else do logTermNF "declare.data" 1 "Previous" Env.empty (type ndef)
+                                             logTermNF "declare.data" 1 "Now" Env.empty fullty
                                              throw (AlreadyDefined fc n)
                       _ => throw (AlreadyDefined fc n)
 
-         logTermNF "declare.data" 5 ("data " ++ show n) ScopeEmpty fullty
+         logTermNF "declare.data" 5 ("data " ++ show n) Env.empty fullty
 
-         arity <- getArity defs ScopeEmpty fullty
+         arity <- getArity defs Env.empty fullty
 
          -- Add the type constructor as a placeholder while checking
          -- data constructors

--- a/src/TTImp/ProcessDecls.idr
+++ b/src/TTImp/ProcessDecls.idr
@@ -212,7 +212,7 @@ processTTImpFile fname
                                 pure False
          traverse_ recordWarning ws
          logTime 0 "Elaboration" $
-            catch (do ignore $ processTTImpDecls (MkNested []) ScopeEmpty tti
+            catch (do ignore $ processTTImpDecls (MkNested []) Env.empty tti
                       Nothing <- checkDelayedHoles
                           | Just err => throw err
                       pure True)

--- a/src/TTImp/ProcessRecord.idr
+++ b/src/TTImp/ProcessRecord.idr
@@ -70,13 +70,13 @@ elabRecord {vars} eopts fc env nest newns def_vis mbtot tn_in params0 opts conNa
 
          -- Go into new namespace, if there is one, for getters
          case newns of
-              Nothing => elabGetters tn conName params 0 [] ScopeEmpty conty
+              Nothing => elabGetters tn conName params 0 [] Env.empty conty
               Just ns =>
                    do let cns = currentNS defs
                       let nns = nestedNS defs
                       extendNS (mkNamespace ns)
                       newns <- getNS
-                      elabGetters tn conName params 0 [] ScopeEmpty conty
+                      elabGetters tn conName params 0 [] Env.empty conty
                       -- Record that the current namespace is allowed to look
                       -- at private names in the nested namespace
                       update Ctxt { currentNS := cns,
@@ -155,7 +155,7 @@ elabRecord {vars} eopts fc env nest newns def_vis mbtot tn_in params0 opts conNa
              Just ty <- lookupTyExact tn (gamma defs)
                | Nothing => throw (InternalError "Missing data type \{show tn}, despite having just declared it!")
              log "declare.record" 20 "Obtained type: \{show ty}"
-             (_ ** (tyenv, ty)) <- dropLeadingPis vars ty ScopeEmpty
+             (_ ** (tyenv, ty)) <- dropLeadingPis vars ty Env.empty
              ty <- unelabNest (NoSugar True) !nestDrop tyenv ty
              log "declare.record.parameters" 30 "Unelaborated type: \{show ty}"
              params <- getParameters [<] ty
@@ -168,7 +168,7 @@ elabRecord {vars} eopts fc env nest newns def_vis mbtot tn_in params0 opts conNa
         -- these local variables from the fully elaborated record's type
         -- We'll use the `env` thus obtained to unelab the remaining scope
         dropLeadingPis : {vs : _} -> (vars : Scope) -> Term vs -> Env Term vs ->
-                         Core (vars' ** (Env Term vars', Term vars'))
+                         Core (vars' : Scope ** (Env Term vars', Term vars'))
         dropLeadingPis [] ty env
           = do unless (null vars) $
                  logC "declare.record.parameters" 60 $ pure $ unlines

--- a/src/TTImp/ProcessType.idr
+++ b/src/TTImp/ProcessType.idr
@@ -39,10 +39,10 @@ getFnString (IPrimVal _ (Str st)) = pure st
 getFnString tm
     = do inidx <- resolveName (UN $ Basic "[foreign]")
          let fc = getFC tm
-         let gstr = gnf ScopeEmpty (PrimVal fc $ PrT StringType)
-         etm <- checkTerm inidx InExpr [] (MkNested []) ScopeEmpty tm gstr
+         let gstr = gnf Env.empty (PrimVal fc $ PrT StringType)
+         etm <- checkTerm inidx InExpr [] (MkNested []) Env.empty tm gstr
          defs <- get Ctxt
-         case !(nf defs ScopeEmpty etm) of
+         case !(nf defs Env.empty etm) of
               NPrimVal fc (Str st) => pure st
               _ => throw (GenericMsg fc "%foreign calling convention must evaluate to a String")
 
@@ -104,10 +104,10 @@ findInferrable defs ty = fi 0 0 [] [] ty
                  Nothing => pure acc
                  Just p => if p `elem` acc then pure acc else pure (p :: acc)
       findInf acc pos (NDCon _ _ _ _ args)
-          = do args' <- traverse (evalClosure defs . snd) (toList args)
+          = do args' <- traverse (evalClosure defs . snd) args
                findInfs acc pos args'
       findInf acc pos (NTCon _ _ _ _ args)
-          = do args' <- traverse (evalClosure defs . snd) (toList args)
+          = do args' <- traverse (evalClosure defs . snd) args
                findInfs acc pos args'
       findInf acc pos (NDelayed _ _ t) = findInf acc pos t
       findInf acc _ _ = pure acc
@@ -119,7 +119,7 @@ findInferrable defs ty = fi 0 0 [] [] ty
     fi : Nat -> Int -> List (Name, Nat) -> List Nat -> ClosedNF -> Core (List Nat)
     fi pos i args acc (NBind fc x (Pi _ _ _ aty) sc)
         = do let argn = MN "inf" i
-             sc' <- sc defs (toClosure defaultOpts ScopeEmpty (Ref fc Bound argn))
+             sc' <- sc defs (toClosure defaultOpts Env.empty (Ref fc Bound argn))
              acc' <- findInf acc args !(evalClosure defs aty)
              rest <- fi (1 + pos) (1 + i) ((argn, pos) :: args) acc' sc'
              pure rest
@@ -164,7 +164,7 @@ processType {vars} eopts nest env fc rig vis opts (MkImpTy tfc n_in ty_raw)
                    checkTerm idx InType (HolesOkay :: eopts) nest env
                              (IBindHere fc (PI erased) ty_raw)
                              (gType fc u)
-         logTermNF "declare.type" 3 ("Type of " ++ show n) ScopeEmpty (abstractFullEnvType tfc env ty)
+         logTermNF "declare.type" 3 ("Type of " ++ show n) Env.empty (abstractFullEnvType tfc env ty)
 
          def <- initDef fc n env ty opts
          let fullty = abstractFullEnvType tfc env ty
@@ -172,7 +172,7 @@ processType {vars} eopts nest env fc rig vis opts (MkImpTy tfc n_in ty_raw)
          (erased, dterased) <- findErased fullty
          defs <- get Ctxt
          empty <- clearDefs defs
-         infargs <- findInferrable empty !(nf defs ScopeEmpty fullty)
+         infargs <- findInferrable empty !(nf defs Env.empty fullty)
 
          ignore $ addDef (Resolved idx)
                 ({ eraseArgs := erased,

--- a/src/TTImp/TTImp.idr
+++ b/src/TTImp/TTImp.idr
@@ -718,7 +718,7 @@ implicitsAs n defs ns tm
                     "Could not find variable " ++ show n
                   pure $ IVar loc nm
             Just ty =>
-               do ty' <- nf defs ScopeEmpty ty
+               do ty' <- nf defs Env.empty ty
                   implicits <- findImps is es ns ty'
                   log "declare.def.lhs.implicits" 30 $
                     "\n  In the type of " ++ show n ++ ": " ++ show ty ++
@@ -755,12 +755,12 @@ implicitsAs n defs ns tm
         -- and explicit variables. So we first peel off all of the quantifiers
         -- corresponding to these variables.
         findImps ns es (_ :: locals) (NBind fc x (Pi _ _ _ _) sc)
-          = do body <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+          = do body <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
                findImps ns es locals body
                -- ^ TODO? check that name of the pi matches name of local?
         -- don't add implicits coming after explicits that aren't given
         findImps ns es [] (NBind fc x (Pi _ _ Explicit _) sc)
-            = do body <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+            = do body <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
                  case es of
                    -- Explicits were skipped, therefore all explicits are given anyway
                    Just (UN Underscore) :: _ => findImps ns es [] body
@@ -770,13 +770,13 @@ implicitsAs n defs ns tm
                           Just es' => findImps ns es' [] body
         -- if the implicit was given, skip it
         findImps ns es [] (NBind fc x (Pi _ _ AutoImplicit _) sc)
-            = do body <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+            = do body <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
                  case updateNs x ns of
                    Nothing => -- didn't find explicit call
                       pure $ (x, AutoImplicit) :: !(findImps ns es [] body)
                    Just ns' => findImps ns' es [] body
         findImps ns es [] (NBind fc x (Pi _ _ p _) sc)
-            = do body <- sc defs (toClosure defaultOpts ScopeEmpty (Erased fc Placeholder))
+            = do body <- sc defs (toClosure defaultOpts Env.empty (Erased fc Placeholder))
                  if Just x `elem` ns
                    then findImps ns es [] body
                    else pure $ (x, forgetDef p) :: !(findImps ns es [] body)

--- a/src/TTImp/Utils.idr
+++ b/src/TTImp/Utils.idr
@@ -290,6 +290,7 @@ findIBindVars tm = []
 
 mutual
   -- Substitute for either an explicit variable name, or a bound variable name
+  -- TODO association list should be map (should the `List Name` be a set as well?)
   substNames' : Bool -> List Name -> List (Name, RawImp) ->
                 RawImp -> RawImp
   substNames' False bound ps (IVar fc n)
@@ -511,6 +512,7 @@ unNameNum (str, Nothing) = str
 unNameNum (str, Just n) = fastConcat [str, "_", show n]
 
 
+-- TODO use a set of `String`s
 export
 uniqueBasicName : Defs -> List String -> String -> Core String
 uniqueBasicName defs used n

--- a/src/Yaffle/REPL.idr
+++ b/src/Yaffle/REPL.idr
@@ -42,10 +42,10 @@ process : {auto c : Ref Ctxt Defs} ->
           {auto o : Ref ROpts REPLOpts} ->
           ImpREPL -> Core Bool
 process (Eval ttimp)
-    = do (tm, _) <- elabTerm 0 InExpr [] (MkNested []) ScopeEmpty ttimp Nothing
+    = do (tm, _) <- elabTerm 0 InExpr [] (MkNested []) Env.empty ttimp Nothing
          defs <- get Ctxt
-         tmnf <- normalise defs ScopeEmpty tm
-         coreLift_ (printLn !(unelab ScopeEmpty tmnf))
+         tmnf <- normalise defs Env.empty tm
+         coreLift_ (printLn !(unelab Env.empty tmnf))
          pure True
 process (Check (IVar _ n))
     = do defs <- get Ctxt
@@ -56,23 +56,23 @@ process (Check (IVar _ n))
     printName : (Name, Int, ClosedTerm) -> Core ()
     printName (n, _, tyh)
         = do defs <- get Ctxt
-             ty <- normaliseHoles defs ScopeEmpty tyh
+             ty <- normaliseHoles defs Env.empty tyh
              coreLift_ $ putStrLn $ show n ++ " : " ++
-                                    show !(unelab ScopeEmpty ty)
+                                    show !(unelab Env.empty ty)
 process (Check ttimp)
-    = do (tm, gty) <- elabTerm 0 InExpr [] (MkNested []) ScopeEmpty ttimp Nothing
+    = do (tm, gty) <- elabTerm 0 InExpr [] (MkNested []) Env.empty ttimp Nothing
          defs <- get Ctxt
          tyh <- getTerm gty
-         ty <- normaliseHoles defs ScopeEmpty tyh
-         coreLift_ (printLn !(unelab ScopeEmpty ty))
+         ty <- normaliseHoles defs Env.empty tyh
+         coreLift_ (printLn !(unelab Env.empty ty))
          pure True
 process (ProofSearch n_in)
     = do defs <- get Ctxt
          [(n, i, ty)] <- lookupTyName n_in (gamma defs)
               | ns => ambiguousName (justFC defaultFC) n_in (map fst ns)
-         def <- search (justFC defaultFC) top False 1000 n ty ScopeEmpty
+         def <- search (justFC defaultFC) top False 1000 n ty Env.empty
          defs <- get Ctxt
-         defnf <- normaliseHoles defs ScopeEmpty def
+         defnf <- normaliseHoles defs Env.empty def
          coreLift_ (printLn !(toFullNames defnf))
          pure True
 process (ExprSearch n_in)

--- a/support/refc/_datatypes.h
+++ b/support/refc/_datatypes.h
@@ -147,7 +147,8 @@ typedef struct {
 
 typedef struct {
   Value_header header;
-  Value *(*f)();
+  // function type depends on arity, see idris2_dispatch_closure
+  void *f;
   uint8_t arity;
   uint8_t filled; // length of args.
   Value *args[];

--- a/support/refc/runtime.c
+++ b/support/refc/runtime.c
@@ -8,55 +8,96 @@ void idris2_missing_ffi() {
   exit(1);
 }
 
+typedef Value *(*const FUN0)();
+typedef Value *(*const FUN1)(Value *);
+typedef Value *(*const FUN2)(Value *, Value *);
+typedef Value *(*const FUN3)(Value *, Value *, Value *);
+typedef Value *(*const FUN4)(Value *, Value *, Value *, Value *);
+typedef Value *(*const FUN5)(Value *, Value *, Value *, Value *, Value *);
+typedef Value *(*const FUN6)(Value *, Value *, Value *, Value *, Value *,
+                             Value *);
+typedef Value *(*const FUN7)(Value *, Value *, Value *, Value *, Value *,
+                             Value *, Value *);
+typedef Value *(*const FUN8)(Value *, Value *, Value *, Value *, Value *,
+                             Value *, Value *, Value *);
+typedef Value *(*const FUN9)(Value *, Value *, Value *, Value *, Value *,
+                             Value *, Value *, Value *, Value *);
+typedef Value *(*const FUN10)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *);
+typedef Value *(*const FUN11)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *);
+typedef Value *(*const FUN12)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *);
+typedef Value *(*const FUN13)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *);
+typedef Value *(*const FUN14)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *);
+typedef Value *(*const FUN15)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *);
+typedef Value *(*const FUN16)(Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *, Value *, Value *, Value *, Value *,
+                              Value *);
+typedef Value *(*const FUNStar)(Value **);
+
 static inline Value *idris2_dispatch_closure(Value_Closure *clo) {
   Value **const xs = clo->args;
-  Value *(*const f)() = clo->f;
 
   switch (clo->arity) {
   default:
-    return (*f)(xs);
+    return (*(FUNStar)clo->f)(xs);
 
   case 0:
-    return (*f)();
+    return (*(FUN0)clo->f)();
   case 1:
-    return (*f)(xs[0]);
+    return (*(FUN1)clo->f)(xs[0]);
   case 2:
-    return (*f)(xs[0], xs[1]);
+    return (*(FUN2)clo->f)(xs[0], xs[1]);
   case 3:
-    return (*f)(xs[0], xs[1], xs[2]);
+    return (*(FUN3)clo->f)(xs[0], xs[1], xs[2]);
   case 4:
-    return (*f)(xs[0], xs[1], xs[2], xs[3]);
+    return (*(FUN4)clo->f)(xs[0], xs[1], xs[2], xs[3]);
   case 5:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4]);
+    return (*(FUN5)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4]);
   case 6:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5]);
+    return (*(FUN6)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5]);
   case 7:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6]);
+    return (*(FUN7)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6]);
   case 8:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7]);
+    return (*(FUN8)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                           xs[7]);
   case 9:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8]);
+    return (*(FUN9)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                           xs[7], xs[8]);
   case 10:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9]);
+    return (*(FUN10)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9]);
   case 11:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9], xs[10]);
+    return (*(FUN11)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9], xs[10]);
   case 12:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9], xs[10], xs[11]);
+    return (*(FUN12)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9], xs[10], xs[11]);
   case 13:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9], xs[10], xs[11], xs[12]);
+    return (*(FUN13)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9], xs[10], xs[11], xs[12]);
   case 14:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9], xs[10], xs[11], xs[12], xs[13]);
+    return (*(FUN14)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9], xs[10], xs[11], xs[12],
+                            xs[13]);
   case 15:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9], xs[10], xs[11], xs[12], xs[13], xs[14]);
+    return (*(FUN15)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9], xs[10], xs[11], xs[12], xs[13],
+                            xs[14]);
   case 16:
-    return (*f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6], xs[7], xs[8],
-                xs[9], xs[10], xs[11], xs[12], xs[13], xs[14], xs[15]);
+    return (*(FUN16)clo->f)(xs[0], xs[1], xs[2], xs[3], xs[4], xs[5], xs[6],
+                            xs[7], xs[8], xs[9], xs[10], xs[11], xs[12], xs[13],
+                            xs[14], xs[15]);
   }
 }
 


### PR DESCRIPTION
Thanks for the PR and your patience! We've went over this PR and these are the main points:

- Reverted `Scopeable`s that act like spines (e.g. `NTCon`) because we consider it to be a separate refactoring
- Disambiguated overloaded `ScopeEmpty` (e.g. `Scope` and `Env`) using namespaces.
- Identified and replaced instances of `All` quantifiers. Both `List` and `SnocList` enjoy all, which will make future changes easier.
- Highlighted opportunities for rewrite-free implementations using fish-based (`<><`) sliding windows.
- Left a bunch of TODOs for unrelated refactoring opportunities.